### PR TITLE
#15 - BinaryOperatorSpacesFixer fixed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,7 +24,7 @@
   },
   "scripts": {
     "ecs": "./vendor/bin/ecs check",
-    "ecs-fix": "./vendor/bin/ecs check --fix",
+    "ecsf": "./vendor/bin/ecs check --fix",
     "test": "./vendor/bin/phpunit tests"
   },
   "require-dev": {

--- a/examples/union_types.php
+++ b/examples/union_types.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+class Whatever
+{
+    public int|string $something;
+
+    /**
+     * @throws JsonException
+     */
+    public function do(): void
+    {
+        $i = 1 + 1;
+        json_encode([$i], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
+    }
+}

--- a/src/Configuration/Defaults/CommonAdditionalRules.php
+++ b/src/Configuration/Defaults/CommonAdditionalRules.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Blumilk\Codestyle\Configuration\Defaults;
 
 use Blumilk\Codestyle\Configuration\AdditionalRules;
+use Blumilk\Codestyle\Fixers\BinaryOperatorSpacesFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoSpacesAfterFunctionNameFixer;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
@@ -27,5 +28,6 @@ class CommonAdditionalRules extends Rules implements AdditionalRules
         NoSpacesAfterFunctionNameFixer::class => null,
         FullyQualifiedStrictTypesFixer::class => null,
         OrderedImportsFixer::class => null,
+        BinaryOperatorSpacesFixer::class => null,
     ];
 }

--- a/src/Configuration/Defaults/CommonSkippedRules.php
+++ b/src/Configuration/Defaults/CommonSkippedRules.php
@@ -6,6 +6,7 @@ namespace Blumilk\Codestyle\Configuration\Defaults;
 
 use Blumilk\Codestyle\Configuration\SkippedRules;
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
+use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
 use PhpCsFixer\Fixer\ReturnNotation\ReturnAssignmentFixer;
 use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
@@ -17,5 +18,6 @@ class CommonSkippedRules extends Rules implements SkippedRules
         ClassAttributesSeparationFixer::class => null,
         NotOperatorWithSuccessorSpaceFixer::class => null,
         ReturnAssignmentFixer::class => null,
+        BinaryOperatorSpacesFixer::class => null,
     ];
 }

--- a/src/Configuration/Defaults/CommonSkippedRules.php
+++ b/src/Configuration/Defaults/CommonSkippedRules.php
@@ -6,7 +6,6 @@ namespace Blumilk\Codestyle\Configuration\Defaults;
 
 use Blumilk\Codestyle\Configuration\SkippedRules;
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
-use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
 use PhpCsFixer\Fixer\ReturnNotation\ReturnAssignmentFixer;
 use PhpCsFixer\Fixer\StringNotation\SingleQuoteFixer;
@@ -18,6 +17,5 @@ class CommonSkippedRules extends Rules implements SkippedRules
         ClassAttributesSeparationFixer::class => null,
         NotOperatorWithSuccessorSpaceFixer::class => null,
         ReturnAssignmentFixer::class => null,
-        BinaryOperatorSpacesFixer::class => null,
     ];
 }

--- a/src/Fixers/BinaryOperatorSpacesFixer.php
+++ b/src/Fixers/BinaryOperatorSpacesFixer.php
@@ -16,8 +16,8 @@ class BinaryOperatorSpacesFixer extends FixerWorkaround
 
     public function __construct()
     {
-        parent::__construct();
         $this->fixer = new BaseBinaryOperatorSpacesFixer();
+        parent::__construct();
     }
 
     protected function getFixer(): BaseBinaryOperatorSpacesFixer
@@ -30,11 +30,11 @@ class BinaryOperatorSpacesFixer extends FixerWorkaround
         $this->tokensAnalyzer = new TokensAnalyzer($tokens);
 
         for ($index = $tokens->count() - 2; $index > 0; --$index) {
-            if (!$this->tokensAnalyzer->isBinaryOperator($index)) {
+            if ($tokens[$index]->getContent() === "|" && $tokens[$index]->getId() === CT::T_TYPE_ALTERNATION) {
                 continue;
             }
 
-            if ($tokens[$index]->getContent() === "|" && $tokens[$index]->getId() === CT::T_TYPE_ALTERNATION) {
+            if (!$this->tokensAnalyzer->isBinaryOperator($index)) {
                 continue;
             }
 

--- a/src/Fixers/BinaryOperatorSpacesFixer.php
+++ b/src/Fixers/BinaryOperatorSpacesFixer.php
@@ -1,0 +1,59 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\Codestyle\Fixers;
+
+use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer as BaseBinaryOperatorSpacesFixer;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixer\Tokenizer\TokensAnalyzer;
+use SplFileInfo;
+
+class BinaryOperatorSpacesFixer extends FixerWorkaround
+{
+    protected BaseBinaryOperatorSpacesFixer $fixer;
+
+    public function __construct()
+    {
+        parent::__construct();
+        $this->fixer = new BaseBinaryOperatorSpacesFixer();
+    }
+
+    protected function getFixer(): BaseBinaryOperatorSpacesFixer
+    {
+        return $this->fixer;
+    }
+
+    protected function applyFix(SplFileInfo $file, Tokens $tokens): void
+    {
+        $this->tokensAnalyzer = new TokensAnalyzer($tokens);
+
+        for ($index = $tokens->count() - 2; $index > 0; --$index) {
+            if (!$this->tokensAnalyzer->isBinaryOperator($index)) {
+                continue;
+            }
+
+            if ($tokens[$index]->getContent() === "|" && $tokens[$index]->getId() === CT::T_TYPE_ALTERNATION) {
+                continue;
+            }
+
+            if ($tokens[$index]->getContent() === "=") {
+                $isDeclare = $this->isEqualPartOfDeclareStatement($tokens, $index);
+                if ($isDeclare === false) {
+                    $this->fixWhiteSpaceAroundOperator($tokens, $index);
+                } else {
+                    $index = $isDeclare;
+                }
+            } else {
+                $this->fixWhiteSpaceAroundOperator($tokens, $index);
+            }
+
+            --$index;
+        }
+
+        if (\count($this->alignOperatorTokens)) {
+            $this->fixAlignment($tokens, $this->alignOperatorTokens);
+        }
+    }
+}

--- a/src/Fixers/FixerWorkaround.php
+++ b/src/Fixers/FixerWorkaround.php
@@ -1,0 +1,51 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\Codestyle\Fixers;
+
+use PhpCsFixer\AbstractFixer;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\Tokens;
+use ReflectionClass;
+use ReflectionException;
+use SplFileInfo;
+
+abstract class FixerWorkaround extends AbstractFixer
+{
+    /**
+     * @throws ReflectionException
+     */
+    public function __call(string $name, array $arguments = []): void
+    {
+        $reflection = new ReflectionClass(get_class($this->getFixer()));
+        $reflectedMethod = $reflection->getMethod($name);
+        $reflectedMethod->setAccessible(true);
+        $reflectedMethod->invoke($this->getFixer(), ...$arguments);
+    }
+
+    /**
+     * @throws ReflectionException
+     */
+    public function __get(string $name): mixed
+    {
+        $reflection = new ReflectionClass(get_class($this->getFixer()));
+        $reflectedProperty = $reflection->getProperty($name);
+        $reflectedProperty->setAccessible(true);
+        return $reflectedProperty->getValue($this->getFixer());
+    }
+
+    public function getDefinition(): FixerDefinition
+    {
+        return $this->getFixer()->getDefinition();
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $this->getFixer()->isCandidate($tokens);
+    }
+
+    abstract protected function applyFix(SplFileInfo $file, Tokens $tokens): void;
+
+    abstract protected function getFixer(): AbstractFixer;
+}

--- a/src/Fixers/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixers/NoSpacesAfterFunctionNameFixer.php
@@ -14,8 +14,8 @@ class NoSpacesAfterFunctionNameFixer extends FixerWorkaround
 
     public function __construct()
     {
-        parent::__construct();
         $this->fixer = new BaseNoSpacesAfterFunctionNameFixer();
+        parent::__construct();
     }
 
     protected function getFixer(): BaseNoSpacesAfterFunctionNameFixer

--- a/src/Fixers/NoSpacesAfterFunctionNameFixer.php
+++ b/src/Fixers/NoSpacesAfterFunctionNameFixer.php
@@ -4,31 +4,23 @@ declare(strict_types=1);
 
 namespace Blumilk\Codestyle\Fixers;
 
-use PhpCsFixer\AbstractFixer;
-use PhpCsFixer\FixerDefinition\CodeSample;
-use PhpCsFixer\FixerDefinition\FixerDefinition;
-use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Fixer\FunctionNotation\NoSpacesAfterFunctionNameFixer as BaseNoSpacesAfterFunctionNameFixer;
 use PhpCsFixer\Tokenizer\Tokens;
 use SplFileInfo;
 
-final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
+class NoSpacesAfterFunctionNameFixer extends FixerWorkaround
 {
-    public function getDefinition(): FixerDefinition
+    protected BaseNoSpacesAfterFunctionNameFixer $fixer;
+
+    public function __construct()
     {
-        return new FixerDefinition(
-            "When making a method or function call, there MUST NOT be a space between the method or function name and the opening parenthesis.",
-            [new CodeSample("<?php\nrequire ('sample.php');\necho (test (3));\nexit  (1);\n\$func ();\n")]
-        );
+        parent::__construct();
+        $this->fixer = new BaseNoSpacesAfterFunctionNameFixer();
     }
 
-    public function getPriority(): int
+    protected function getFixer(): BaseNoSpacesAfterFunctionNameFixer
     {
-        return 2;
-    }
-
-    public function isCandidate(Tokens $tokens): bool
-    {
-        return $tokens->isAnyTokenKindsFound(array_merge($this->getFunctionyTokenKinds(), [T_STRING]));
+        return $this->fixer;
     }
 
     protected function applyFix(SplFileInfo $file, Tokens $tokens): void
@@ -61,7 +53,7 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
                 if (!$tokens[$possibleDefinitionIndex]->isGivenKind(T_FUNCTION)) {
                     $this->fixFunctionCall($tokens, $index);
                 }
-            } elseif ($tokens[$lastTokenIndex]->equalsAny($braceTypes)) {
+            } elseif ($tokens[$lastTokenIndex]->equalsAny($braceTypes ?? [])) {
                 $block = Tokens::detectBlockType($tokens[$lastTokenIndex]);
                 if (
                     $block["type"] === Tokens::BLOCK_TYPE_ARRAY_INDEX_CURLY_BRACE
@@ -75,28 +67,9 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
         }
     }
 
-    private function fixFunctionCall(Tokens $tokens, int $index): void
+    protected function getFunctionyTokenKinds(): array
     {
-        if ($tokens[$index - 1]->isWhitespace()) {
-            $tokens->clearAt($index - 1);
-        }
-    }
-
-    private function getBraceAfterVariableKinds(): array
-    {
-        static $tokens = [
-            ")",
-            "]",
-            [CT::T_DYNAMIC_VAR_BRACE_CLOSE],
-            [CT::T_ARRAY_INDEX_CURLY_BRACE_CLOSE],
-        ];
-
-        return $tokens;
-    }
-
-    private function getFunctionyTokenKinds(): array
-    {
-        static $tokens = [
+        return [
             T_ARRAY,
             T_ECHO,
             T_EMPTY,
@@ -113,21 +86,5 @@ final class NoSpacesAfterFunctionNameFixer extends AbstractFixer
             T_VARIABLE,
             T_FN,
         ];
-
-        return $tokens;
-    }
-
-    private function getLanguageConstructionTokenKinds(): array
-    {
-        static $languageConstructionTokens = [
-            T_ECHO,
-            T_PRINT,
-            T_INCLUDE,
-            T_INCLUDE_ONCE,
-            T_REQUIRE,
-            T_REQUIRE_ONCE,
-        ];
-
-        return $languageConstructionTokens;
     }
 }

--- a/tests/AdditionalRulesConfigurationTest.php
+++ b/tests/AdditionalRulesConfigurationTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 use Blumilk\Codestyle\Config;
 use Blumilk\Codestyle\Configuration\Defaults\CommonAdditionalRules;
 use Blumilk\Codestyle\Configuration\Utils\Rule;
+use Blumilk\Codestyle\Fixers\BinaryOperatorSpacesFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoSpacesAfterFunctionNameFixer;
 use PhpCsFixer\Fixer\Alias\NoMixedEchoPrintFixer;
@@ -36,6 +37,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                 NoSpacesAfterFunctionNameFixer::class => null,
                 FullyQualifiedStrictTypesFixer::class => null,
                 OrderedImportsFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
             ],
             $config->options()["rules"]
         );
@@ -63,6 +65,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                 NoSpacesAfterFunctionNameFixer::class => null,
                 FullyQualifiedStrictTypesFixer::class => null,
                 OrderedImportsFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
             ],
             $config->options()["rules"]
         );
@@ -87,6 +90,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                 NoSpacesAfterFunctionNameFixer::class => null,
                 FullyQualifiedStrictTypesFixer::class => null,
                 OrderedImportsFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
                 HeredocToNowdocFixer::class => null,
             ],
             $config->options()["rules"]
@@ -116,6 +120,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                 NoSpacesAfterFunctionNameFixer::class => null,
                 FullyQualifiedStrictTypesFixer::class => null,
                 OrderedImportsFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
                 NoMixedEchoPrintFixer::class => [
                     "use" => "echo",
                 ],

--- a/tests/SkippedRulesConfigurationTest.php
+++ b/tests/SkippedRulesConfigurationTest.php
@@ -7,7 +7,6 @@ use Blumilk\Codestyle\Configuration\Defaults\CommonSkippedRules;
 use Blumilk\Codestyle\Configuration\Utils\Rule;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
-use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\LogicalOperatorsFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
 use PhpCsFixer\Fixer\ReturnNotation\ReturnAssignmentFixer;
@@ -21,13 +20,15 @@ class SkippedRulesConfigurationTest extends TestCase
         $skipped = new CommonSkippedRules();
         $config = new Config(skipped: $skipped);
 
-        $this->assertSame([
-            SingleQuoteFixer::class => null,
-            ClassAttributesSeparationFixer::class => null,
-            NotOperatorWithSuccessorSpaceFixer::class => null,
-            ReturnAssignmentFixer::class => null,
-            BinaryOperatorSpacesFixer::class => null,
-        ], $config->options()["skipped"]);
+        $this->assertSame(
+            [
+                SingleQuoteFixer::class => null,
+                ClassAttributesSeparationFixer::class => null,
+                NotOperatorWithSuccessorSpaceFixer::class => null,
+                ReturnAssignmentFixer::class => null,
+            ],
+            $config->options()["skipped"]
+        );
     }
 
     public function testClearingSkippedRulesConfiguration(): void
@@ -37,16 +38,19 @@ class SkippedRulesConfigurationTest extends TestCase
 
         $this->assertSame([], $config->options()["skipped"]);
     }
+
     public function testFilteringSkippedRulesConfiguration(): void
     {
         $skipped = new CommonSkippedRules();
         $config = new Config(skipped: $skipped->filter(ReturnAssignmentFixer::class, SingleQuoteFixer::class));
 
-        $this->assertSame([
-            ClassAttributesSeparationFixer::class => null,
-            NotOperatorWithSuccessorSpaceFixer::class => null,
-            BinaryOperatorSpacesFixer::class => null,
-        ], $config->options()["skipped"]);
+        $this->assertSame(
+            [
+                ClassAttributesSeparationFixer::class => null,
+                NotOperatorWithSuccessorSpaceFixer::class => null,
+            ],
+            $config->options()["skipped"]
+        );
     }
 
     public function testExtendingSkippedRulesConfiguration(): void
@@ -56,14 +60,16 @@ class SkippedRulesConfigurationTest extends TestCase
             skipped: $skipped->add(new Rule(LogicalOperatorsFixer::class))
         );
 
-        $this->assertSame([
-            SingleQuoteFixer::class => null,
-            ClassAttributesSeparationFixer::class => null,
-            NotOperatorWithSuccessorSpaceFixer::class => null,
-            ReturnAssignmentFixer::class => null,
-            BinaryOperatorSpacesFixer::class => null,
-            LogicalOperatorsFixer::class => null,
-        ], $config->options()["skipped"]);
+        $this->assertSame(
+            [
+                SingleQuoteFixer::class => null,
+                ClassAttributesSeparationFixer::class => null,
+                NotOperatorWithSuccessorSpaceFixer::class => null,
+                ReturnAssignmentFixer::class => null,
+                LogicalOperatorsFixer::class => null,
+            ],
+            $config->options()["skipped"]
+        );
     }
 
     public function testExtendingWithOptionsSkippedRulesConfiguration(): void
@@ -73,13 +79,15 @@ class SkippedRulesConfigurationTest extends TestCase
             skipped: $skipped->add(new Rule(ArraySyntaxFixer::class, [__DIR__ . "/test"]))
         );
 
-        $this->assertSame([
-            SingleQuoteFixer::class => null,
-            ClassAttributesSeparationFixer::class => null,
-            NotOperatorWithSuccessorSpaceFixer::class => null,
-            ReturnAssignmentFixer::class => null,
-            BinaryOperatorSpacesFixer::class => null,
-            ArraySyntaxFixer::class => [__DIR__ . "/test"],
-        ], $config->options()["skipped"]);
+        $this->assertSame(
+            [
+                SingleQuoteFixer::class => null,
+                ClassAttributesSeparationFixer::class => null,
+                NotOperatorWithSuccessorSpaceFixer::class => null,
+                ReturnAssignmentFixer::class => null,
+                ArraySyntaxFixer::class => [__DIR__ . "/test"],
+            ],
+            $config->options()["skipped"]
+        );
     }
 }

--- a/tests/SkippedRulesConfigurationTest.php
+++ b/tests/SkippedRulesConfigurationTest.php
@@ -7,6 +7,7 @@ use Blumilk\Codestyle\Configuration\Defaults\CommonSkippedRules;
 use Blumilk\Codestyle\Configuration\Utils\Rule;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
+use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\LogicalOperatorsFixer;
 use PhpCsFixer\Fixer\Operator\NotOperatorWithSuccessorSpaceFixer;
 use PhpCsFixer\Fixer\ReturnNotation\ReturnAssignmentFixer;
@@ -26,6 +27,7 @@ class SkippedRulesConfigurationTest extends TestCase
                 ClassAttributesSeparationFixer::class => null,
                 NotOperatorWithSuccessorSpaceFixer::class => null,
                 ReturnAssignmentFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
             ],
             $config->options()["skipped"]
         );
@@ -48,6 +50,7 @@ class SkippedRulesConfigurationTest extends TestCase
             [
                 ClassAttributesSeparationFixer::class => null,
                 NotOperatorWithSuccessorSpaceFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
             ],
             $config->options()["skipped"]
         );
@@ -66,6 +69,7 @@ class SkippedRulesConfigurationTest extends TestCase
                 ClassAttributesSeparationFixer::class => null,
                 NotOperatorWithSuccessorSpaceFixer::class => null,
                 ReturnAssignmentFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
                 LogicalOperatorsFixer::class => null,
             ],
             $config->options()["skipped"]
@@ -85,6 +89,7 @@ class SkippedRulesConfigurationTest extends TestCase
                 ClassAttributesSeparationFixer::class => null,
                 NotOperatorWithSuccessorSpaceFixer::class => null,
                 ReturnAssignmentFixer::class => null,
+                BinaryOperatorSpacesFixer::class => null,
                 ArraySyntaxFixer::class => [__DIR__ . "/test"],
             ],
             $config->options()["skipped"]


### PR DESCRIPTION
Now this is correct:

```php
<?php

declare(strict_types=1);

class Whatever
{
    public int|string $something;

    /**
     * @throws JsonException
     */
    public function do(): void
    {
        $i = 1 + 1;
        json_encode([$i], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
    }
}
```