### PR TITLE
#19 - removing useless phpdoc comments

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,9 +13,6 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Validate composer.json
-        run: composer validate
-
       - name: Run the Docker containers
         run: docker-compose up -d
 
@@ -26,6 +23,9 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('**/composer.lock') }}
           restore-keys: |
             ${{ runner.os }}-composer-
+
+      - name: Validate composer.json
+        run: docker-compose run php composer validate
 
       - name: Install dependencies
         run: docker-compose run php composer install --prefer-dist --no-progress --no-suggest

--- a/composer.json
+++ b/composer.json
@@ -1,12 +1,12 @@
 {
   "name": "blumilksoftware/codestyle",
   "description": "Blumilk codestyle configurator",
+  "license": "MIT",
   "type": "library",
   "require": {
     "php": "^8.0",
     "symplify/easy-coding-standard": "^9.2"
   },
-  "license": "MIT",
   "authors": [
     {
       "name": "Krzysztof Rewak",

--- a/readme.md
+++ b/readme.md
@@ -58,40 +58,49 @@ return $config->config();
 ```
 
 #### Usage with Composer
-Add script to your `composer.json` file:
+Add scripts to your `composer.json` file:
 ```json
-"scripts": {
-  "ecs": "./vendor/bin/ecs check"
+{
+  "scripts": {
+    "ecs": "./vendor/bin/ecs check",
+    "ecsf": "./vendor/bin/ecs check --fix"
+  }
 }
 ```
 
-Then run:
+Then run following command to check codestyle:
 ```shell
 composer ecs
 ```
 
-# Contributing
+or following to fix found errors:
+```shell
+composer ecsf
+```
 
-### Requirements
-- docker
-- docker-compose
-
-### installation
-
+### Contributing
+In cloned or forked repository, run:
 ```shell
 cp .env.example .env
-# adjust '.env' file
-docker-compose up -d
-docker-compose exec php composer install
-```
-### shell
-```shell
-docker-compose exec php ash
+composer install
 ```
 
-### scripts
+There are scripts available for package codestyle checking and testing:
 ```shell
-docker-compose exec php composer ecs
-docker-compose exec php composer ecsf
-docker-compose exec php composer test
+composer ecs
+composer ecsf
+composer test
 ```
+
+There is also the Docker Compose configuration available:
+```shell
+docker-compose up -d
+docker-compose exec php php -v
+docker-compose exec php composer -V
+```
+
+Please maintain our project guidelines:
+* keep issues well described, labeled and in English,
+* add issue number to all your commits,
+* add issue number to your branch name,
+* squash your commits into one commit with standardized name.

--- a/src/Configuration/Defaults/CommonAdditionalRules.php
+++ b/src/Configuration/Defaults/CommonAdditionalRules.php
@@ -13,8 +13,10 @@ use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
+use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
+use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 
 class CommonAdditionalRules extends Rules implements AdditionalRules
 {
@@ -34,5 +36,12 @@ class CommonAdditionalRules extends Rules implements AdditionalRules
             "const" => "single",
             "property" => "single",
         ],
+        GeneralPhpdocAnnotationRemoveFixer::class => [
+            "annotations" => [
+                "package",
+                "author",
+            ],
+        ],
+        NoExtraBlankLinesFixer::class => null,
     ];
 }

--- a/tests/AdditionalRulesConfigurationTest.php
+++ b/tests/AdditionalRulesConfigurationTest.php
@@ -138,8 +138,8 @@ class AdditionalRulesConfigurationTest extends TestCase
         $rules = new CommonAdditionalRules();
         $rule = new Rule(
             NoMixedEchoPrintFixer::class, [
-            "use" => "echo",
-        ]
+                                            "use" => "echo",
+                                        ]
         );
 
         $config = new Config(

--- a/tests/AdditionalRulesConfigurationTest.php
+++ b/tests/AdditionalRulesConfigurationTest.php
@@ -137,9 +137,10 @@ class AdditionalRulesConfigurationTest extends TestCase
     {
         $rules = new CommonAdditionalRules();
         $rule = new Rule(
-            NoMixedEchoPrintFixer::class, [
-                                            "use" => "echo",
-                                        ]
+            NoMixedEchoPrintFixer::class,
+            [
+                "use" => "echo",
+            ]
         );
 
         $config = new Config(

--- a/tests/AdditionalRulesConfigurationTest.php
+++ b/tests/AdditionalRulesConfigurationTest.php
@@ -14,9 +14,11 @@ use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
+use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\StringNotation\HeredocToNowdocFixer;
+use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PHPUnit\Framework\TestCase;
 
 class AdditionalRulesConfigurationTest extends TestCase
@@ -43,6 +45,13 @@ class AdditionalRulesConfigurationTest extends TestCase
                     "const" => "single",
                     "property" => "single",
                 ],
+                GeneralPhpdocAnnotationRemoveFixer::class => [
+                    "annotations" => [
+                        "package",
+                        "author",
+                    ],
+                ],
+                NoExtraBlankLinesFixer::class => null,
             ],
             $config->options()["rules"]
         );
@@ -75,6 +84,13 @@ class AdditionalRulesConfigurationTest extends TestCase
                     "const" => "single",
                     "property" => "single",
                 ],
+                GeneralPhpdocAnnotationRemoveFixer::class => [
+                    "annotations" => [
+                        "package",
+                        "author",
+                    ],
+                ],
+                NoExtraBlankLinesFixer::class => null,
             ],
             $config->options()["rules"]
         );
@@ -104,6 +120,13 @@ class AdditionalRulesConfigurationTest extends TestCase
                     "const" => "single",
                     "property" => "single",
                 ],
+                GeneralPhpdocAnnotationRemoveFixer::class => [
+                    "annotations" => [
+                        "package",
+                        "author",
+                    ],
+                ],
+                NoExtraBlankLinesFixer::class => null,
                 HeredocToNowdocFixer::class => null,
             ],
             $config->options()["rules"]
@@ -113,9 +136,11 @@ class AdditionalRulesConfigurationTest extends TestCase
     public function testExtendingWithOptionsAdditionalRulesConfiguration(): void
     {
         $rules = new CommonAdditionalRules();
-        $rule = new Rule(NoMixedEchoPrintFixer::class, [
+        $rule = new Rule(
+            NoMixedEchoPrintFixer::class, [
             "use" => "echo",
-        ]);
+        ]
+        );
 
         $config = new Config(
             rules: $rules->add($rule)
@@ -138,6 +163,13 @@ class AdditionalRulesConfigurationTest extends TestCase
                     "const" => "single",
                     "property" => "single",
                 ],
+                GeneralPhpdocAnnotationRemoveFixer::class => [
+                    "annotations" => [
+                        "package",
+                        "author",
+                    ],
+                ],
+                NoExtraBlankLinesFixer::class => null,
                 NoMixedEchoPrintFixer::class => [
                     "use" => "echo",
                 ],

--- a/tests/LaravelPathsConfigurationTest.php
+++ b/tests/LaravelPathsConfigurationTest.php
@@ -13,8 +13,10 @@ class LaravelPathsConfigurationTest extends TestCase
         $paths = new LaravelPaths();
         $config = new Config(paths: $paths);
 
-        $this->assertSame(["app", "config", "database", "resources/lang", "routes", "tests"],
-            $config->options()["paths"]);
+        $this->assertSame(
+            ["app", "config", "database", "resources/lang", "routes", "tests"],
+            $config->options()["paths"]
+        );
     }
 
     public function testFilteredLaravelPathsConfiguration(): void
@@ -22,8 +24,10 @@ class LaravelPathsConfigurationTest extends TestCase
         $paths = new LaravelPaths();
         $config = new Config(paths: $paths->filter("resources/lang"));
 
-        $this->assertSame(["app", "config", "database", "routes", "tests"],
-            $config->options()["paths"]);
+        $this->assertSame(
+            ["app", "config", "database", "routes", "tests"],
+            $config->options()["paths"]
+        );
     }
 
     public function testClearedLaravelPathsConfiguration(): void


### PR DESCRIPTION
After this change, all useless comments will be removed:

Before:
```php
<?php

declare(strict_types=1);

/**
 * Class Whatever
 */
class Whatever
{
    public int|string $something;

    /**
     * @throws JsonException
     */
    public function do(): void
    {
        $i = 1 + 1;
        json_encode([$i], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
    }
}
```

After:
```php
<?php

declare(strict_types=1);

class Whatever
{
    public int|string $something;

    /**
     * @throws JsonException
     */
    public function do(): void
    {
        $i = 1 + 1;
        json_encode([$i], JSON_THROW_ON_ERROR | JSON_UNESCAPED_SLASHES);
    }
}
```

This should close #19.
