### PR TITLE
#30 - enforce trailing commas

### DIFF
--- a/ecs.php
+++ b/ecs.php
@@ -6,7 +6,7 @@ use Blumilk\Codestyle\Config;
 use Blumilk\Codestyle\Configuration\Defaults\Paths;
 
 $config = new Config(
-    paths: new Paths("ecs.php", "src", "tests/unit", "tests/codestyle/CodestyleTest.php", "tests/codestyle/config.php")
+    paths: new Paths("ecs.php", "src", "tests/unit", "tests/codestyle/CodestyleTest.php", "tests/codestyle/config.php"),
 );
 
 return $config->config();

--- a/ecs.php
+++ b/ecs.php
@@ -6,7 +6,7 @@ use Blumilk\Codestyle\Config;
 use Blumilk\Codestyle\Configuration\Defaults\Paths;
 
 $config = new Config(
-    paths: new Paths("src", "tests/unit", "tests/codestyle/CodestyleTest.php")
+    paths: new Paths("ecs.php", "src", "tests/unit", "tests/codestyle/CodestyleTest.php", "tests/codestyle/config.php")
 );
 
 return $config->config();

--- a/readme.md
+++ b/readme.md
@@ -35,7 +35,7 @@ use Blumilk\Codestyle\Configuration\Defaults\LaravelPaths;
 $paths = new LaravelPaths();
 
 $config = new Config(
-    paths: $paths->filter("app", "tests")->add("src")
+    paths: $paths->filter("app", "tests")->add("src"),
 );
 
 return $config->config();
@@ -51,7 +51,7 @@ use Blumilk\Codestyle\Config;
 use Blumilk\Codestyle\Configuration\Defaults\Paths;
 
 $config = new Config(
-    paths: new Paths("src")
+    paths: new Paths("src"),
 );
 
 return $config->config();

--- a/src/Config.php
+++ b/src/Config.php
@@ -27,7 +27,7 @@ class Config
         ?Paths $paths = null,
         ?SetLists $sets = null,
         ?SkippedRules $skipped = null,
-        ?AdditionalRules $rules = null
+        ?AdditionalRules $rules = null,
     ) {
         $this->paths = $paths ?? new LaravelPaths();
         $this->sets = $sets ?? new CommonSetLists();

--- a/src/Configuration/Defaults/CommonAdditionalRules.php
+++ b/src/Configuration/Defaults/CommonAdditionalRules.php
@@ -9,6 +9,7 @@ use Blumilk\Codestyle\Fixers\BinaryOperatorSpacesFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoSpacesAfterFunctionNameFixer;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
+use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
@@ -43,5 +44,12 @@ class CommonAdditionalRules extends Rules implements AdditionalRules
             ],
         ],
         NoExtraBlankLinesFixer::class => null,
+        TrailingCommaInMultilineFixer::class => [
+            "elements" => [
+                "arrays",
+                "parameters",
+                "arguments",
+            ],
+        ],
     ];
 }

--- a/src/Fixers/DoubleQuoteFixer.php
+++ b/src/Fixers/DoubleQuoteFixer.php
@@ -24,7 +24,7 @@ EOF;
             "Convert single quotes to double quotes for simple strings.",
             [
                 new CodeSample($codeSample),
-            ]
+            ],
         );
     }
 

--- a/tests/codestyle/config.php
+++ b/tests/codestyle/config.php
@@ -6,7 +6,7 @@ use Blumilk\Codestyle\Config;
 use Blumilk\Codestyle\Configuration\Defaults\Paths;
 
 $config = new Config(
-    paths: new Paths("./tests/codestyle/tmp")
+    paths: new Paths("./tests/codestyle/tmp"),
 );
 
 return $config->config();

--- a/tests/codestyle/fixtures/trailingCommas/actual.php
+++ b/tests/codestyle/fixtures/trailingCommas/actual.php
@@ -1,0 +1,28 @@
+<?php
+
+class TrailingCommasExample
+{
+    public function testArguments(): string
+    {
+        return $this->testParameters(
+            "a",
+            "b"
+        );
+    }
+
+    public function testParameters(
+        string $a,
+        string $b
+    ): string {
+        return "${a}-${b}";
+    }
+
+    public function testArrays(): array
+    {
+        return [
+            1,
+            2,
+            3
+        ];
+    }
+}

--- a/tests/codestyle/fixtures/trailingCommas/expected.php
+++ b/tests/codestyle/fixtures/trailingCommas/expected.php
@@ -1,0 +1,30 @@
+<?php
+
+declare(strict_types=1);
+
+class TrailingCommasExample
+{
+    public function testArguments(): string
+    {
+        return $this->testParameters(
+            "a",
+            "b",
+        );
+    }
+
+    public function testParameters(
+        string $a,
+        string $b,
+    ): string {
+        return "${a}-${b}";
+    }
+
+    public function testArrays(): array
+    {
+        return [
+            1,
+            2,
+            3,
+        ];
+    }
+}

--- a/tests/unit/AdditionalRulesConfigurationTest.php
+++ b/tests/unit/AdditionalRulesConfigurationTest.php
@@ -10,6 +10,7 @@ use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoSpacesAfterFunctionNameFixer;
 use PhpCsFixer\Fixer\Alias\NoMixedEchoPrintFixer;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
+use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
@@ -52,8 +53,15 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                TrailingCommaInMultilineFixer::class => [
+                    "elements" => [
+                        "arrays",
+                        "parameters",
+                        "arguments",
+                    ],
+                ],
             ],
-            $config->options()["rules"]
+            $config->options()["rules"],
         );
     }
 
@@ -91,8 +99,15 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                TrailingCommaInMultilineFixer::class => [
+                    "elements" => [
+                        "arrays",
+                        "parameters",
+                        "arguments",
+                    ],
+                ],
             ],
-            $config->options()["rules"]
+            $config->options()["rules"],
         );
     }
 
@@ -100,7 +115,7 @@ class AdditionalRulesConfigurationTest extends TestCase
     {
         $rules = new CommonAdditionalRules();
         $config = new Config(
-            rules: $rules->add(new Rule(HeredocToNowdocFixer::class))
+            rules: $rules->add(new Rule(HeredocToNowdocFixer::class)),
         );
 
         $this->assertSame(
@@ -127,9 +142,16 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                TrailingCommaInMultilineFixer::class => [
+                    "elements" => [
+                        "arrays",
+                        "parameters",
+                        "arguments",
+                    ],
+                ],
                 HeredocToNowdocFixer::class => null,
             ],
-            $config->options()["rules"]
+            $config->options()["rules"],
         );
     }
 
@@ -140,11 +162,11 @@ class AdditionalRulesConfigurationTest extends TestCase
             NoMixedEchoPrintFixer::class,
             [
                 "use" => "echo",
-            ]
+            ],
         );
 
         $config = new Config(
-            rules: $rules->add($rule)
+            rules: $rules->add($rule),
         );
 
         $this->assertSame(
@@ -171,11 +193,18 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                TrailingCommaInMultilineFixer::class => [
+                    "elements" => [
+                        "arrays",
+                        "parameters",
+                        "arguments",
+                    ],
+                ],
                 NoMixedEchoPrintFixer::class => [
                     "use" => "echo",
                 ],
             ],
-            $config->options()["rules"]
+            $config->options()["rules"],
         );
     }
 }

--- a/tests/unit/LaravelPathsConfigurationTest.php
+++ b/tests/unit/LaravelPathsConfigurationTest.php
@@ -15,7 +15,7 @@ class LaravelPathsConfigurationTest extends TestCase
 
         $this->assertSame(
             ["app", "config", "database", "resources/lang", "routes", "tests"],
-            $config->options()["paths"]
+            $config->options()["paths"],
         );
     }
 
@@ -26,7 +26,7 @@ class LaravelPathsConfigurationTest extends TestCase
 
         $this->assertSame(
             ["app", "config", "database", "routes", "tests"],
-            $config->options()["paths"]
+            $config->options()["paths"],
         );
     }
 

--- a/tests/unit/SkippedRulesConfigurationTest.php
+++ b/tests/unit/SkippedRulesConfigurationTest.php
@@ -29,7 +29,7 @@ class SkippedRulesConfigurationTest extends TestCase
                 ReturnAssignmentFixer::class => null,
                 BinaryOperatorSpacesFixer::class => null,
             ],
-            $config->options()["skipped"]
+            $config->options()["skipped"],
         );
     }
 
@@ -52,7 +52,7 @@ class SkippedRulesConfigurationTest extends TestCase
                 NotOperatorWithSuccessorSpaceFixer::class => null,
                 BinaryOperatorSpacesFixer::class => null,
             ],
-            $config->options()["skipped"]
+            $config->options()["skipped"],
         );
     }
 
@@ -60,7 +60,7 @@ class SkippedRulesConfigurationTest extends TestCase
     {
         $skipped = new CommonSkippedRules();
         $config = new Config(
-            skipped: $skipped->add(new Rule(LogicalOperatorsFixer::class))
+            skipped: $skipped->add(new Rule(LogicalOperatorsFixer::class)),
         );
 
         $this->assertSame(
@@ -72,7 +72,7 @@ class SkippedRulesConfigurationTest extends TestCase
                 BinaryOperatorSpacesFixer::class => null,
                 LogicalOperatorsFixer::class => null,
             ],
-            $config->options()["skipped"]
+            $config->options()["skipped"],
         );
     }
 
@@ -80,7 +80,7 @@ class SkippedRulesConfigurationTest extends TestCase
     {
         $skipped = new CommonSkippedRules();
         $config = new Config(
-            skipped: $skipped->add(new Rule(ArraySyntaxFixer::class, [__DIR__ . "/test"]))
+            skipped: $skipped->add(new Rule(ArraySyntaxFixer::class, [__DIR__ . "/test"])),
         );
 
         $this->assertSame(
@@ -92,7 +92,7 @@ class SkippedRulesConfigurationTest extends TestCase
                 BinaryOperatorSpacesFixer::class => null,
                 ArraySyntaxFixer::class => [__DIR__ . "/test"],
             ],
-            $config->options()["skipped"]
+            $config->options()["skipped"],
         );
     }
 }


### PR DESCRIPTION
it should close #30

<details>
  <summary>Before</summary>
  
```php
<?php

class TrailingCommasExample
{
    public function testArguments(): string
    {
        return $this->testParameters(
            "a",
            "b"
        );
    }

    public function testParameters(
        string $a,
        string $b
    ): string {
        return "${a}-${b}";
    }

    public function testArrays(): array
    {
        return [
            1,
            2,
            3
        ];
    }
}
  ```
  
</details>

<details>
  <summary>After</summary>
  
```php
<?php

declare(strict_types=1);

class TrailingCommasExample
{
    public function testArguments(): string
    {
        return $this->testParameters(
            "a",
            "b",
        );
    }

    public function testParameters(
        string $a,
        string $b,
    ): string {
        return "${a}-${b}";
    }

    public function testArrays(): array
    {
        return [
            1,
            2,
            3,
        ];
    }
}
  ```
  
</details>