### PR TITLE
#26 - spaces around operators

### DIFF
--- a/src/Configuration/Defaults/CommonAdditionalRules.php
+++ b/src/Configuration/Defaults/CommonAdditionalRules.php
@@ -8,6 +8,7 @@ use Blumilk\Codestyle\Configuration\AdditionalRules;
 use Blumilk\Codestyle\Fixers\BinaryOperatorSpacesFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoSpacesAfterFunctionNameFixer;
+use PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
 use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
@@ -43,5 +44,6 @@ class CommonAdditionalRules extends Rules implements AdditionalRules
             ],
         ],
         NoExtraBlankLinesFixer::class => null,
+        OperatorSpacingSniff::class => null,
     ];
 }

--- a/tests/codestyle/fixtures/operatorSpacing/actual.php
+++ b/tests/codestyle/fixtures/operatorSpacing/actual.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+$a=1+2;
+
+$b=$a===3;
+
+$c=$a<5;
+
+$d=!$c;

--- a/tests/codestyle/fixtures/operatorSpacing/expected.php
+++ b/tests/codestyle/fixtures/operatorSpacing/expected.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+$a = 1 + 2;
+
+$b = $a === 3;
+
+$c = $a < 5;
+
+$d = !$c;

--- a/tests/unit/AdditionalRulesConfigurationTest.php
+++ b/tests/unit/AdditionalRulesConfigurationTest.php
@@ -8,6 +8,7 @@ use Blumilk\Codestyle\Configuration\Utils\Rule;
 use Blumilk\Codestyle\Fixers\BinaryOperatorSpacesFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoSpacesAfterFunctionNameFixer;
+use PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff;
 use PhpCsFixer\Fixer\Alias\NoMixedEchoPrintFixer;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
 use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
@@ -52,6 +53,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                OperatorSpacingSniff::class => null,
             ],
             $config->options()["rules"]
         );
@@ -91,6 +93,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                OperatorSpacingSniff::class => null,
             ],
             $config->options()["rules"]
         );
@@ -127,6 +130,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                OperatorSpacingSniff::class => null,
                 HeredocToNowdocFixer::class => null,
             ],
             $config->options()["rules"]
@@ -171,6 +175,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                     ],
                 ],
                 NoExtraBlankLinesFixer::class => null,
+                OperatorSpacingSniff::class => null,
                 NoMixedEchoPrintFixer::class => [
                     "use" => "echo",
                 ],


### PR DESCRIPTION
It should close #26 

<details>
  <summary>Before</summary>
  
```php
<?php

declare(strict_types=1);

$a=1+2;

$b=$a===3;

$c=$a<5;

$d=!$c;
  ```
  
</details>

<details>
  <summary>After</summary>
  
```php
<?php

declare(strict_types=1);

$a = 1 + 2;

$b = $a === 3;

$c = $a < 5;

$d = !$c;
  ```
  
</details>