### PR TITLE
#40 - forcing nullable type declaration for default null values

### DIFF
--- a/src/Configuration/Defaults/CommonAdditionalRules.php
+++ b/src/Configuration/Defaults/CommonAdditionalRules.php
@@ -11,6 +11,7 @@ use Blumilk\Codestyle\Fixers\NoSpacesAfterFunctionNameFixer;
 use PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
+use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
@@ -60,5 +61,6 @@ class CommonAdditionalRules extends Rules implements AdditionalRules
                 "arguments",
             ],
         ],
+        NullableTypeDeclarationForDefaultNullValueFixer::class => null,
     ];
 }

--- a/tests/codestyle/fixtures/nullableTypeForDefaultNull/actual.php
+++ b/tests/codestyle/fixtures/nullableTypeForDefaultNull/actual.php
@@ -1,0 +1,14 @@
+<?php
+
+class NullableTypeForDefaultNull
+{
+    public function getNameLabel(string $name, string $title = null): string
+    {
+        $label = $name;
+        if ($title !== null) {
+            $label .= " " . $title;
+        }
+
+        return $label;
+    }
+}

--- a/tests/codestyle/fixtures/nullableTypeForDefaultNull/expected.php
+++ b/tests/codestyle/fixtures/nullableTypeForDefaultNull/expected.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+class NullableTypeForDefaultNull
+{
+    public function getNameLabel(string $name, ?string $title = null): string
+    {
+        $label = $name;
+        if ($title !== null) {
+            $label .= " " . $title;
+        }
+
+        return $label;
+    }
+}

--- a/tests/unit/AdditionalRulesConfigurationTest.php
+++ b/tests/unit/AdditionalRulesConfigurationTest.php
@@ -12,6 +12,7 @@ use PHP_CodeSniffer\Standards\PSR12\Sniffs\Operators\OperatorSpacingSniff;
 use PhpCsFixer\Fixer\Alias\NoMixedEchoPrintFixer;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
+use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\UseArrowFunctionsFixer;
 use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
 use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
@@ -69,6 +70,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                         "arguments",
                     ],
                 ],
+                NullableTypeDeclarationForDefaultNullValueFixer::class => null,
             ],
             $config->options()["rules"],
         );
@@ -123,6 +125,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                         "arguments",
                     ],
                 ],
+                NullableTypeDeclarationForDefaultNullValueFixer::class => null,
             ],
             $config->options()["rules"],
         );
@@ -174,6 +177,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                         "arguments",
                     ],
                 ],
+                NullableTypeDeclarationForDefaultNullValueFixer::class => null,
                 HeredocToNowdocFixer::class => null,
             ],
             $config->options()["rules"],
@@ -233,6 +237,7 @@ class AdditionalRulesConfigurationTest extends TestCase
                         "arguments",
                     ],
                 ],
+                NullableTypeDeclarationForDefaultNullValueFixer::class => null,
                 NoMixedEchoPrintFixer::class => [
                     "use" => "echo",
                 ],


### PR DESCRIPTION
Before:
```php
<?php

class NullableTypeForDefaultNull
{
    public function getNameLabel(string $name, string $title = null): string
    {
        $label = $name;
        if ($title !== null) {
            $label .= " " . $title;
        }

        return $label;
    }
}
```

After:
```php
<?php

declare(strict_types=1);

class NullableTypeForDefaultNull
{
    public function getNameLabel(string $name, ?string $title = null): string
    {
        $label = $name;
        if ($title !== null) {
            $label .= " " . $title;
        }

        return $label;
    }
}
```