### PR TITLE
#42 - enums fixed with SwitchCaseSemicolonToColonFixer update

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,6 +13,12 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: 8.1
+          coverage: none
+
       - name: Cache composer dependencies
         uses: actions/cache@v2
         with:

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -10,13 +10,17 @@ jobs:
   build:
     runs-on: ubuntu-20.04
 
+    strategy:
+      matrix:
+        php: ["8.0", "8.1"]
+
     steps:
       - uses: actions/checkout@v2
 
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: 8.1
+          php-version: ${{ matrix.php }}
           coverage: none
 
       - name: Cache composer dependencies

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "require": {
     "php": "^8.0",
-    "symplify/easy-coding-standard": "9.4.70"
+    "symplify/easy-coding-standard": "10.0.0"
   },
   "require-dev": {
     "composer/composer": "2.*",

--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "require": {
     "php": "^8.0",
-    "symplify/easy-coding-standard": "10.0.0"
+    "symplify/easy-coding-standard": "10.0.2"
   },
   "require-dev": {
     "composer/composer": "2.*",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   php:
-    image: ghcr.io/blumilksoftware/php:8.0.3.1
+    image: ghcr.io/blumilksoftware/php:8.1.0.0
     container_name: blumilk-codestyle-php
     working_dir: /application
     user: ${CURRENT_UID:-1000}

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -38,7 +38,7 @@ class CodestyleTest extends TestCase
         $result = 0;
         $output = null;
 
-        exec("./vendor/bin/composer " . $command, $output, $result);
+        exec("./vendor/bin/composer " . $command . " 2> /dev/null", $output, $result);
 
         return $result === 0;
     }
@@ -49,6 +49,7 @@ class CodestyleTest extends TestCase
     protected function testFixture(string $name): void
     {
         copy(__DIR__ . "/fixtures/${name}/actual.php", __DIR__ . "/tmp/${name}.php");
+
         $this->assertFalse($this->runComposerEcsCommand());
         $this->assertTrue($this->runComposerEcsCommand(true));
         $this->assertFileEquals(__DIR__ . "/fixtures/${name}/expected.php", __DIR__ . "/tmp/${name}.php");

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -6,6 +6,16 @@ use PHPUnit\Framework\TestCase;
 
 class CodestyleTest extends TestCase
 {
+    protected function setUp(): void
+    {
+        $this->clearTempDirectory();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->clearTempDirectory();
+    }
+
     /**
      * @requires PHP >= 8.0
      * @throws Exception
@@ -41,16 +51,6 @@ class CodestyleTest extends TestCase
         foreach ($fixtures as $fixture) {
             $this->testFixture($fixture);
         }
-    }
-
-    protected function setUp(): void
-    {
-        $this->clearTempDirectory();
-    }
-
-    protected function tearDown(): void
-    {
-        $this->clearTempDirectory();
     }
 
     /**

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -6,6 +6,43 @@ use PHPUnit\Framework\TestCase;
 
 class CodestyleTest extends TestCase
 {
+    /**
+     * @requires PHP >= 8.0
+     * @throws Exception
+     */
+    public function testPhp80Fixtures(): void
+    {
+        $fixtures = [
+            "noExtraBlankLines",
+            "noExtraBlankLines",
+            "nullableTypeForDefaultNull",
+            "operatorSpacing",
+            "singleQuotes",
+            "strictTypes",
+            "trailingCommas",
+            "unionTypes",
+        ];
+
+        foreach ($fixtures as $fixture) {
+            $this->testFixture($fixture);
+        }
+    }
+
+    /**
+     * @requires PHP >= 8.1
+     * @throws Exception
+     */
+    public function testPhp81Fixtures(): void
+    {
+        $fixtures = [
+            "enums",
+        ];
+
+        foreach ($fixtures as $fixture) {
+            $this->testFixture($fixture);
+        }
+    }
+
     protected function setUp(): void
     {
         $this->clearTempDirectory();
@@ -14,19 +51,6 @@ class CodestyleTest extends TestCase
     protected function tearDown(): void
     {
         $this->clearTempDirectory();
-    }
-
-    /**
-     * @throws Exception
-     */
-    public function testFixtures(): void
-    {
-        $fixtures = scandir(__DIR__ . "/fixtures");
-        $fixtures = array_filter($fixtures, fn(string $dir): bool => !str_contains($dir, "."));
-
-        foreach ($fixtures as $fixture) {
-            $this->testFixture($fixture);
-        }
     }
 
     /**

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -74,9 +74,9 @@ class CodestyleTest extends TestCase
     {
         copy(__DIR__ . "/fixtures/${name}/actual.php", __DIR__ . "/tmp/${name}.php");
 
-        $this->assertFalse($this->runComposerEcsCommand());
-        $this->assertTrue($this->runComposerEcsCommand(true));
-        $this->assertFileEquals(__DIR__ . "/fixtures/${name}/expected.php", __DIR__ . "/tmp/${name}.php");
+        $this->assertFalse($this->runComposerEcsCommand(), "Fixture fixtures/$name returned invalid true result.");
+        $this->assertTrue($this->runComposerEcsCommand(true), "Fixture fixtures/$name was not proceeded properly.");
+        $this->assertFileEquals(__DIR__ . "/fixtures/${name}/expected.php", __DIR__ . "/tmp/${name}.php", "Result of proceeded fixture fixtures/$name is not equal to expected.");
     }
 
     protected function clearTempDirectory(): void

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -74,9 +74,9 @@ class CodestyleTest extends TestCase
     {
         copy(__DIR__ . "/fixtures/${name}/actual.php", __DIR__ . "/tmp/${name}.php");
 
-        $this->assertFalse($this->runComposerEcsCommand(), "Fixture fixtures/$name returned invalid true result.");
-        $this->assertTrue($this->runComposerEcsCommand(true), "Fixture fixtures/$name was not proceeded properly.");
-        $this->assertFileEquals(__DIR__ . "/fixtures/${name}/expected.php", __DIR__ . "/tmp/${name}.php", "Result of proceeded fixture fixtures/$name is not equal to expected.");
+        $this->assertFalse($this->runComposerEcsCommand(), "Fixture fixtures/${name} returned invalid true result.");
+        $this->assertTrue($this->runComposerEcsCommand(true), "Fixture fixtures/${name} was not proceeded properly.");
+        $this->assertFileEquals(__DIR__ . "/fixtures/${name}/expected.php", __DIR__ . "/tmp/${name}.php", "Result of proceeded fixture fixtures/${name} is not equal to expected.");
     }
 
     protected function clearTempDirectory(): void

--- a/tests/codestyle/fixtures/enums/actual.php
+++ b/tests/codestyle/fixtures/enums/actual.php
@@ -1,0 +1,7 @@
+<?php
+
+enum Status: string
+{
+    case ACTIVE = "active";
+    case INACTIVE = "inactive";
+}

--- a/tests/codestyle/fixtures/enums/expected.php
+++ b/tests/codestyle/fixtures/enums/expected.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+enum Status: string
+{
+    case ACTIVE = "active";
+    case INACTIVE = "inactive";
+}


### PR DESCRIPTION
Okay, so I updated ECS and PHP-CS_Fixer underneath. Enums are working properly right now.

The problem to discuss is versioning. I bumped development environment Docker to 8.1 and everything is okay. But if anyone would like to run tests with PHP 8.0, then it'd break because it'd not understand enum syntax. Generally Codestyle as a package should work with PHP 8.0 projects (the problem is for internal testing only).

Should we exclude this one particular test from test cases for PHP < 8.1? Or maybe we should just bump required PHP version to 8.1? I'm open to discussion.

It should close #42.