### PR TITLE
#45 - references in method signatures

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "require": {
     "php": "^8.0",
-    "symplify/easy-coding-standard": "10.0.2"
+    "symplify/easy-coding-standard": "10.0.8"
   },
   "require-dev": {
     "composer/composer": "2.*",

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -31,6 +31,7 @@ class CodestyleTest extends TestCase
             "strictTypes",
             "trailingCommas",
             "unionTypes",
+            "references",
         ];
 
         foreach ($fixtures as $fixture) {
@@ -46,6 +47,7 @@ class CodestyleTest extends TestCase
     {
         $fixtures = [
             "enums",
+            "readonlies",
         ];
 
         foreach ($fixtures as $fixture) {

--- a/tests/codestyle/fixtures/readonlies/actual.php
+++ b/tests/codestyle/fixtures/readonlies/actual.php
@@ -1,0 +1,10 @@
+<?php
+
+class ReadonlyThing
+{
+    protected readonly bool $true;
+
+    public function __construct(protected readonly string $string)
+    {
+    }
+}

--- a/tests/codestyle/fixtures/readonlies/expected.php
+++ b/tests/codestyle/fixtures/readonlies/expected.php
@@ -1,0 +1,13 @@
+<?php
+
+declare(strict_types=1);
+
+class ReadonlyThing
+{
+    protected readonly bool $true;
+
+    public function __construct(
+        protected readonly string $string,
+    ) {
+    }
+}

--- a/tests/codestyle/fixtures/references/actual.php
+++ b/tests/codestyle/fixtures/references/actual.php
@@ -1,0 +1,8 @@
+<?php
+
+class ReferencedMethodParameter
+{
+    protected function test(array & $param): void
+    {
+    }
+}

--- a/tests/codestyle/fixtures/references/expected.php
+++ b/tests/codestyle/fixtures/references/expected.php
@@ -1,0 +1,10 @@
+<?php
+
+declare(strict_types=1);
+
+class ReferencedMethodParameter
+{
+    protected function test(array &$param): void
+    {
+    }
+}


### PR DESCRIPTION
I bumped ECS underneath, so readonlies and references in methods should be working now.

Should close #45.