### PR TITLE
#49 - deprecated InternalClassCasingFixer removed

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,7 +6,7 @@
   "require": {
     "php": "^8.0",
     "kubawerlos/php-cs-fixer-custom-fixers": "^3.7",
-    "symplify/easy-coding-standard": "10.0.21"
+    "symplify/easy-coding-standard": "10.1.0"
   },
   "require-dev": {
     "composer/composer": "2.*",

--- a/ecs.php
+++ b/ecs.php
@@ -6,7 +6,13 @@ use Blumilk\Codestyle\Config;
 use Blumilk\Codestyle\Configuration\Defaults\Paths;
 
 $config = new Config(
-    paths: new Paths("ecs.php", "src", "tests/unit", "tests/codestyle/CodestyleTest.php", "tests/codestyle/config.php"),
+    paths: new Paths(
+        "ecs.php",
+        "src",
+        "tests/unit",
+        "tests/codestyle/CodestyleTest.php",
+        "tests/codestyle/config.php",
+    ),
 );
 
 return $config->config();

--- a/licence.md
+++ b/licence.md
@@ -1,21 +1,9 @@
 MIT License
 
-Copyright (c) 2021 Blumilk
+Copyright (c) 2021-22 Blumilk
 
-Permission is hereby granted, free of charge, to any person obtaining a copy
-of this software and associated documentation files (the "Software"), to deal
-in the Software without restriction, including without limitation the rights
-to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
-copies of the Software, and to permit persons to whom the Software is
-furnished to do so, subject to the following conditions:
+Permission is hereby granted, free of charge, to any person obtaining a copy of this software and associated documentation files (the "Software"), to deal in the Software without restriction, including without limitation the rights to use, copy, modify, merge, publish, distribute, sublicense, and/or sell copies of the Software, and to permit persons to whom the Software is furnished to do so, subject to the following conditions:
 
-The above copyright notice and this permission notice shall be included in all
-copies or substantial portions of the Software.
+The above copyright notice and this permission notice shall be included in all copies or substantial portions of the Software.
 
-THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
-IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
-FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
-AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
-LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
-OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
-SOFTWARE.
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.

--- a/src/Configuration/Defaults/CommonAdditionalRules.php
+++ b/src/Configuration/Defaults/CommonAdditionalRules.php
@@ -21,7 +21,6 @@ use PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixerCustomFixers\Fixer\ConstructorEmptyBracesFixer;
-use PhpCsFixerCustomFixers\Fixer\InternalClassCasingFixer;
 use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocArrayStyleFixer;
@@ -72,7 +71,6 @@ class CommonAdditionalRules extends Rules implements AdditionalRules
         ],
         NullableTypeDeclarationForDefaultNullValueFixer::class => null,
         ConstructorEmptyBracesFixer::class => null,
-        InternalClassCasingFixer::class => null,
         MultilinePromotedPropertiesFixer::class => null,
         NoUselessCommentFixer::class => null,
         PhpdocArrayStyleFixer::class => null,

--- a/tests/unit/AdditionalRulesConfigurationTest.php
+++ b/tests/unit/AdditionalRulesConfigurationTest.php
@@ -23,7 +23,6 @@ use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\StringNotation\HeredocToNowdocFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixerCustomFixers\Fixer\ConstructorEmptyBracesFixer;
-use PhpCsFixerCustomFixers\Fixer\InternalClassCasingFixer;
 use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocArrayStyleFixer;
@@ -81,7 +80,6 @@ class AdditionalRulesConfigurationTest extends TestCase
                 ],
                 NullableTypeDeclarationForDefaultNullValueFixer::class => null,
                 ConstructorEmptyBracesFixer::class => null,
-                InternalClassCasingFixer::class => null,
                 MultilinePromotedPropertiesFixer::class => null,
                 NoUselessCommentFixer::class => null,
                 PhpdocArrayStyleFixer::class => null,
@@ -145,7 +143,6 @@ class AdditionalRulesConfigurationTest extends TestCase
                 ],
                 NullableTypeDeclarationForDefaultNullValueFixer::class => null,
                 ConstructorEmptyBracesFixer::class => null,
-                InternalClassCasingFixer::class => null,
                 MultilinePromotedPropertiesFixer::class => null,
                 NoUselessCommentFixer::class => null,
                 PhpdocArrayStyleFixer::class => null,
@@ -206,7 +203,6 @@ class AdditionalRulesConfigurationTest extends TestCase
                 ],
                 NullableTypeDeclarationForDefaultNullValueFixer::class => null,
                 ConstructorEmptyBracesFixer::class => null,
-                InternalClassCasingFixer::class => null,
                 MultilinePromotedPropertiesFixer::class => null,
                 NoUselessCommentFixer::class => null,
                 PhpdocArrayStyleFixer::class => null,
@@ -275,7 +271,6 @@ class AdditionalRulesConfigurationTest extends TestCase
                 ],
                 NullableTypeDeclarationForDefaultNullValueFixer::class => null,
                 ConstructorEmptyBracesFixer::class => null,
-                InternalClassCasingFixer::class => null,
                 MultilinePromotedPropertiesFixer::class => null,
                 NoUselessCommentFixer::class => null,
                 PhpdocArrayStyleFixer::class => null,


### PR DESCRIPTION
It should close #49 and fix #48.

I removed deprecated `InternalClassCasingFixer`. It looks like after that everything is working fine.