### PR TITLE
#55 - class attributes separation and useless parenthesis

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -17,9 +17,7 @@ use PhpCsFixerCustomFixers\Fixers as PhpCsFixerCustomFixers;
 class Config
 {
     protected Paths $paths;
-
     protected Rules $rules;
-
     protected string $rootPath;
 
     public function __construct(

--- a/src/Config.php
+++ b/src/Config.php
@@ -17,7 +17,9 @@ use PhpCsFixerCustomFixers\Fixers as PhpCsFixerCustomFixers;
 class Config
 {
     protected Paths $paths;
+
     protected Rules $rules;
+
     protected string $rootPath;
 
     public function __construct(

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -15,6 +15,7 @@ use PhpCsFixer\Fixer\Casing\MagicConstantCasingFixer;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
 use PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer;
 use PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer;
+use PhpCsFixer\Fixer\ClassNotation\ClassAttributesSeparationFixer;
 use PhpCsFixer\Fixer\ClassNotation\ClassDefinitionFixer;
 use PhpCsFixer\Fixer\ClassNotation\NoBlankLinesAfterClassOpeningFixer;
 use PhpCsFixer\Fixer\ClassNotation\OrderedClassElementsFixer;
@@ -197,5 +198,6 @@ class CommonRules extends Rules
         ShortScalarCastFixer::class => null,
         CleanNamespaceFixer::class => null,
         UnaryOperatorSpacesFixer::class => null,
+        ClassAttributesSeparationFixer::class => true,
     ];
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -83,6 +83,7 @@ use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixerCustomFixers\Fixer\ConstructorEmptyBracesFixer;
 use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
+use PhpCsFixerCustomFixers\Fixer\NoUselessParenthesisFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocArrayStyleFixer;
 use PhpCsFixerCustomFixers\Fixer\PromotedConstructorPropertyFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer;
@@ -199,5 +200,6 @@ class CommonRules extends Rules
         CleanNamespaceFixer::class => null,
         UnaryOperatorSpacesFixer::class => null,
         ClassAttributesSeparationFixer::class => true,
+        NoUselessParenthesisFixer::class => true,
     ];
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -199,7 +199,15 @@ class CommonRules extends Rules
         ShortScalarCastFixer::class => null,
         CleanNamespaceFixer::class => null,
         UnaryOperatorSpacesFixer::class => null,
-        ClassAttributesSeparationFixer::class => true,
+        ClassAttributesSeparationFixer::class => [
+            "elements" => [
+                "property" => ClassAttributesSeparationFixer::SPACING_NONE,
+                "const" => ClassAttributesSeparationFixer::SPACING_ONE,
+                "method" => ClassAttributesSeparationFixer::SPACING_ONE,
+                "trait_import" => ClassAttributesSeparationFixer::SPACING_NONE,
+                "case" => ClassAttributesSeparationFixer::SPACING_NONE,
+            ],
+        ],
         NoUselessParenthesisFixer::class => true,
     ];
 }

--- a/src/Configuration/Defaults/LaravelPaths.php
+++ b/src/Configuration/Defaults/LaravelPaths.php
@@ -7,6 +7,7 @@ namespace Blumilk\Codestyle\Configuration\Defaults;
 class LaravelPaths extends Paths
 {
     public const LARAVEL_8_PATHS = ["app", "bootstrap/app.php", "config", "database", "public/index.php", "resources/lang", "routes", "tests"];
+
     public const LARAVEL_9_PATHS = ["app", "bootstrap/app.php", "config", "database", "lang", "public/index.php", "routes", "tests"];
 
     public function __construct(array $paths = self::LARAVEL_9_PATHS)

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -34,6 +34,7 @@ class CodestyleTest extends TestCase
             "trailingCommas",
             "unionTypes",
             "references",
+            "classAttributesSeparation",
         ];
 
         foreach ($fixtures as $fixture) {

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -35,6 +35,7 @@ class CodestyleTest extends TestCase
             "unionTypes",
             "references",
             "classAttributesSeparation",
+            "noUselessParenthesisFixer",
         ];
 
         foreach ($fixtures as $fixture) {

--- a/tests/codestyle/fixtures/classAttributesSeparation/actual.php
+++ b/tests/codestyle/fixtures/classAttributesSeparation/actual.php
@@ -2,7 +2,12 @@
 
 class classAttributesSeparationExample
 {
+    use ExampleTraitOne;
+
+    use ExampleTraitTwo;
+
     protected string $exampleA;
+
     protected string $exampleB;
     public function testFunctionA(string $a): string
     {

--- a/tests/codestyle/fixtures/classAttributesSeparation/actual.php
+++ b/tests/codestyle/fixtures/classAttributesSeparation/actual.php
@@ -1,0 +1,13 @@
+<?php
+
+class classAttributesSeparationExample
+{
+    public function testFunctionA(string $a): string
+    {
+        return $a;
+    }
+    public function testFunctionB(string $b): string
+    {
+        return $b;
+    }
+}

--- a/tests/codestyle/fixtures/classAttributesSeparation/actual.php
+++ b/tests/codestyle/fixtures/classAttributesSeparation/actual.php
@@ -4,7 +4,6 @@ class classAttributesSeparationExample
 {
     protected string $exampleA;
     protected string $exampleB;
-
     public function testFunctionA(string $a): string
     {
         return $a;

--- a/tests/codestyle/fixtures/classAttributesSeparation/actual.php
+++ b/tests/codestyle/fixtures/classAttributesSeparation/actual.php
@@ -2,6 +2,9 @@
 
 class classAttributesSeparationExample
 {
+    protected string $exampleA;
+    protected string $exampleB;
+
     public function testFunctionA(string $a): string
     {
         return $a;

--- a/tests/codestyle/fixtures/classAttributesSeparation/expected.php
+++ b/tests/codestyle/fixtures/classAttributesSeparation/expected.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+class classAttributesSeparationExample
+{
+    public function testFunctionA(string $a): string
+    {
+        return $a;
+    }
+
+    public function testFunctionB(string $b): string
+    {
+        return $b;
+    }
+}

--- a/tests/codestyle/fixtures/classAttributesSeparation/expected.php
+++ b/tests/codestyle/fixtures/classAttributesSeparation/expected.php
@@ -4,8 +4,10 @@ declare(strict_types=1);
 
 class classAttributesSeparationExample
 {
-    protected string $exampleA;
+    use ExampleTraitOne;
+    use ExampleTraitTwo;
 
+    protected string $exampleA;
     protected string $exampleB;
 
     public function testFunctionA(string $a): string

--- a/tests/codestyle/fixtures/classAttributesSeparation/expected.php
+++ b/tests/codestyle/fixtures/classAttributesSeparation/expected.php
@@ -4,6 +4,10 @@ declare(strict_types=1);
 
 class classAttributesSeparationExample
 {
+    protected string $exampleA;
+
+    protected string $exampleB;
+
     public function testFunctionA(string $a): string
     {
         return $a;

--- a/tests/codestyle/fixtures/noUselessParenthesisFixer/actual.php
+++ b/tests/codestyle/fixtures/noUselessParenthesisFixer/actual.php
@@ -1,0 +1,8 @@
+<?php
+
+declare(strict_types=1);
+
+if (($a === 1))
+{
+
+}

--- a/tests/codestyle/fixtures/noUselessParenthesisFixer/expected.php
+++ b/tests/codestyle/fixtures/noUselessParenthesisFixer/expected.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+if ($a === 1)
+{
+}


### PR DESCRIPTION
This should close #55.
Added `NoUselessParenthesisFixer` and `ClassAttributesSeparationFixer` from Kuba Werłos custom fixers.

**ClassAttributesSeparationFixer**
Before:
```php
<?php

class classAttributesSeparationExample
{
    use $exampleTraitA;
    use $exampleTraitB;
    protected string $exampleA;
    protected string $exampleB;

    public function testFunctionA(string $a): string
    {
        return $a;
    }
    public function testFunctionB(string $b): string
    {
        return $b;
    }
}
```

After:
```php
<?php

declare(strict_types=1);

class classAttributesSeparationExample
{
    use $exampleTraitA;
    use $exampleTraitB;

    protected string $exampleA;
    protected string $exampleB;

    public function testFunctionA(string $a): string
    {
        return $a;
    }

    public function testFunctionB(string $b): string
    {
        return $b;
    }
}
```

**NoUselessParenthesisFixer**
Before:
```php
<?php

declare(strict_types=1);

if (($a === 1))
{

}
```

After:
```php
<?php

declare(strict_types=1);

if ($a === 1)
{
}
```