### PR TITLE
#58 - remove Laravel migrations stub comments

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "require": {
     "php": "^8.0",
-    "friendsofphp/php-cs-fixer": "^3.8.0",
+    "friendsofphp/php-cs-fixer": "^3.10.1",
     "kubawerlos/php-cs-fixer-custom-fixers": "^3.7"
   },
   "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": "^8.0",
-    "friendsofphp/php-cs-fixer": "^3.10.1",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.7"
+    "friendsofphp/php-cs-fixer": "^3.8.0",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.10.1"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",

--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,7 @@ use Blumilk\Codestyle\Configuration\Defaults\LaravelPaths;
 use Blumilk\Codestyle\Configuration\Paths;
 use Blumilk\Codestyle\Configuration\Rules;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
+use Blumilk\Codestyle\Fixers\NoLaravelMigrationsGeneratedCommentFixer;
 use JetBrains\PhpStorm\ArrayShape;
 use PhpCsFixer\Config as PhpCsFixerConfig;
 use PhpCsFixer\Finder;
@@ -81,6 +82,7 @@ class Config
     {
         return [
             new DoubleQuoteFixer(),
+            new NoLaravelMigrationsGeneratedCommentFixer(),
         ];
     }
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Blumilk\Codestyle\Configuration\Defaults;
 
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
+use Blumilk\Codestyle\Fixers\NoLaravelMigrationsGeneratedCommentFixer;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoTrailingCommaInSinglelineArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
@@ -211,5 +212,6 @@ class CommonRules extends Rules
         ],
         NoUselessParenthesisFixer::class => true,
         SingleBlankLineAtEofFixer::class => true,
+        NoLaravelMigrationsGeneratedCommentFixer::class => true,
     ];
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -82,11 +82,17 @@ use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoSpacesAroundOffsetFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
+use PhpCsFixerCustomFixers\Fixer\CommentedOutFunctionFixer;
 use PhpCsFixerCustomFixers\Fixer\ConstructorEmptyBracesFixer;
 use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
+use PhpCsFixerCustomFixers\Fixer\NoCommentedOutCodeFixer;
+use PhpCsFixerCustomFixers\Fixer\NoPhpStormGeneratedCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessCommentFixer;
 use PhpCsFixerCustomFixers\Fixer\NoUselessParenthesisFixer;
 use PhpCsFixerCustomFixers\Fixer\PhpdocArrayStyleFixer;
+use PhpCsFixerCustomFixers\Fixer\PhpdocNoIncorrectVarAnnotationFixer;
+use PhpCsFixerCustomFixers\Fixer\PhpdocNoSuperfluousParamFixer;
+use PhpCsFixerCustomFixers\Fixer\PhpdocParamOrderFixer;
 use PhpCsFixerCustomFixers\Fixer\PromotedConstructorPropertyFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceAfterStatementFixer;
 use PhpCsFixerCustomFixers\Fixer\SingleSpaceBeforeStatementFixer;
@@ -203,15 +209,23 @@ class CommonRules extends Rules
         UnaryOperatorSpacesFixer::class => null,
         ClassAttributesSeparationFixer::class => [
             "elements" => [
-                "property" => ClassAttributesSeparationFixer::SPACING_NONE,
-                "const" => ClassAttributesSeparationFixer::SPACING_NONE,
-                "method" => ClassAttributesSeparationFixer::SPACING_ONE,
-                "trait_import" => ClassAttributesSeparationFixer::SPACING_NONE,
-                "case" => ClassAttributesSeparationFixer::SPACING_NONE,
+                "property" => "none",
+                "const" => "none",
+                "method" => "one",
+                "trait_import" => "none",
+                "case" => "none",
             ],
         ],
         NoUselessParenthesisFixer::class => true,
         SingleBlankLineAtEofFixer::class => true,
         NoLaravelMigrationsGeneratedCommentFixer::class => true,
+        CommentedOutFunctionFixer::class => [
+            "functions" => ["print_r", "var_dump", "var_export", "dd"],
+        ],
+        NoCommentedOutCodeFixer::class => true,
+        NoPhpStormGeneratedCommentFixer::class => true,
+        PhpdocNoIncorrectVarAnnotationFixer::class => true,
+        PhpdocNoSuperfluousParamFixer::class => true,
+        PhpdocParamOrderFixer::class => true,
     ];
 }

--- a/src/Fixers/NoLaravelMigrationsGeneratedCommentFixer.php
+++ b/src/Fixers/NoLaravelMigrationsGeneratedCommentFixer.php
@@ -1,0 +1,105 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\Codestyle\Fixers;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Fixer\FunctionNotation\VoidReturnFixer;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixerCustomFixers\TokenRemover;
+use SplFileInfo;
+
+final class NoLaravelMigrationsGeneratedCommentFixer implements FixerInterface
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        $codeSample = <<<'EOF'
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create("sessions", function (Blueprint $table) {
+            $table->string("id")->primary();
+            $table->text("payload");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists("sessions");
+    }
+};
+EOF;
+
+        return new FixerDefinition(
+            "There can be no comments generated in Laravel migrations stub.",
+            [
+                new CodeSample($codeSample),
+            ],
+        );
+    }
+
+    public function getName(): string
+    {
+        return "Blumilk/no_laravel_migrations_generated_comments";
+    }
+
+    public function getPriority(): int
+    {
+        $fixer = new VoidReturnFixer();
+        return $fixer->getPriority() + 1;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isAnyTokenKindsFound([T_COMMENT, T_DOC_COMMENT]);
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index > 0; $index--) {
+            if (!$tokens[$index]->isGivenKind([T_COMMENT, T_DOC_COMMENT])) {
+                continue;
+            }
+
+            if (
+                !str_contains($tokens[$index]->getContent(), "Run the migrations.")
+                && !str_contains($tokens[$index]->getContent(), "Reverse the migrations.")
+            ) {
+                continue;
+            }
+
+            TokenRemover::removeWithLinesIfPossible($tokens, $index);
+        }
+    }
+}

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -36,6 +36,7 @@ class CodestyleTest extends TestCase
             "references",
             "classAttributesSeparation",
             "noUselessParenthesisFixer",
+            "laravelMigrations",
         ];
 
         foreach ($fixtures as $fixture) {

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -37,6 +37,7 @@ class CodestyleTest extends TestCase
             "classAttributesSeparation",
             "noUselessParenthesisFixer",
             "laravelMigrations",
+            "phpdocs",
         ];
 
         foreach ($fixtures as $fixture) {

--- a/tests/codestyle/fixtures/laravelMigrations/actual.php
+++ b/tests/codestyle/fixtures/laravelMigrations/actual.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create("sessions", function (Blueprint $table) {
+            $table->string("id")->primary();
+            $table->text("payload");
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists("sessions");
+    }
+};

--- a/tests/codestyle/fixtures/laravelMigrations/expected.php
+++ b/tests/codestyle/fixtures/laravelMigrations/expected.php
@@ -1,0 +1,22 @@
+<?php
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class() extends Migration {
+    public function up(): void
+    {
+        Schema::create("sessions", function (Blueprint $table): void {
+            $table->string("id")->primary();
+            $table->text("payload");
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists("sessions");
+    }
+};

--- a/tests/codestyle/fixtures/phpdocs/actual.php
+++ b/tests/codestyle/fixtures/phpdocs/actual.php
@@ -1,0 +1,32 @@
+<?php
+/**
+ * Created by PhpStorm.
+ * User: root
+ * Date: 01.01.70
+ * Time: 12:00
+ */
+
+declare(strict_types=1);
+
+/**
+ * @author John Kowalski
+ */
+class Stub
+{
+    protected int $i = 0;
+
+    public function fly(): void
+    {
+        // $this->changePosition();
+        dd($this);
+    }
+
+    /**
+     * @param int $i
+     * @param int $j
+     */
+    public function add(int $i): void
+    {
+        $this->i = $this->i + $i;
+    }
+}

--- a/tests/codestyle/fixtures/phpdocs/expected.php
+++ b/tests/codestyle/fixtures/phpdocs/expected.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+class Stub
+{
+    protected int $i = 0;
+
+    public function fly(): void
+    {
+    }
+
+    public function add(int $i): void
+    {
+        $this->i = $this->i + $i;
+    }
+}


### PR DESCRIPTION
This should close #58 and #38.

With this proposed changes following code:

```php
<?php

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

return new class extends Migration
{
    /**
     * Run the migrations.
     *
     * @return void
     */
    public function up()
    {
        Schema::create("sessions", function (Blueprint $table) {
            $table->string("id")->primary();
            $table->text("payload");
        });
    }

    /**
     * Reverse the migrations.
     *
     * @return void
     */
    public function down()
    {
        Schema::dropIfExists("sessions");
    }
};
```

would be restyled into:
```php
<?php

declare(strict_types=1);

use Illuminate\Database\Migrations\Migration;
use Illuminate\Database\Schema\Blueprint;
use Illuminate\Support\Facades\Schema;

return new class() extends Migration {
    public function up(): void
    {
        Schema::create("sessions", function (Blueprint $table): void {
            $table->string("id")->primary();
            $table->text("payload");
        });
    }

    public function down(): void
    {
        Schema::dropIfExists("sessions");
    }
};
```