### PR TITLE
#68 - do not enforce ${} string interpolation

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -13,7 +13,12 @@ Add package to our project:
 composer require blumilksoftware/codestyle --dev
 ```
 
-Then create `codestyle.php` file in your project's root directory:
+Then run following to create configuration file and add scripts to the `composer.json` file:
+```shell
+./vendor/bin/codestyle init
+```
+
+Or you can create `codestyle.php` file in your project's root directory:
 ```php
 <?php
 

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -74,7 +74,6 @@ use PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
-use PhpCsFixer\Fixer\StringNotation\ExplicitStringVariableFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
@@ -109,7 +108,6 @@ class CommonRules extends Rules
         ArraySyntaxFixer::class => ["syntax" => "short"],
         PhpUnitMethodCasingFixer::class => true,
         FunctionToConstantFixer::class => true,
-        ExplicitStringVariableFixer::class => true,
         ExplicitIndirectVariableFixer::class => true,
         SingleClassElementPerStatementFixer::class => ["elements" => ["const", "property"]],
         NewWithBracesFixer::class => true,


### PR DESCRIPTION
`ExplicitStringVariableFixer` was forcing us to add curly braces for string interpolation. As it's mostly useless and annoying and it probably will be deprecated with PHP 8.2, I'm removing it from common rules.

This should close #68.