### PR TITLE
#69 - added non-yoda style fixer

### DIFF
--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -30,6 +30,7 @@ use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUnneededCurlyBracesFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
+use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer;
 use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
@@ -229,5 +230,10 @@ class CommonRules extends Rules
         PhpdocParamOrderFixer::class => true,
         BracesFixer::class => null,
         NoSpacesInsideParenthesisFixer::class => null,
+        YodaStyleFixer::class => [
+            "equal" => false,
+            "identical" => false,
+            "less_and_greater" => false,
+        ],
     ];
 }

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -38,6 +38,7 @@ class CodestyleTest extends TestCase
             "noUselessParenthesisFixer",
             "laravelMigrations",
             "phpdocs",
+            "yodaStyle",
         ];
 
         foreach ($fixtures as $fixture) {

--- a/tests/codestyle/fixtures/yodaStyle/actual.php
+++ b/tests/codestyle/fixtures/yodaStyle/actual.php
@@ -1,0 +1,5 @@
+<?php
+
+if (null === $a) {
+    echo "null";
+}

--- a/tests/codestyle/fixtures/yodaStyle/actual.php
+++ b/tests/codestyle/fixtures/yodaStyle/actual.php
@@ -3,3 +3,23 @@
 if (null === $a) {
     echo "null";
 }
+
+if (null == $a) {
+    echo "null";
+}
+
+if (3 >= $a) {
+    echo 3;
+}
+
+if (3 <= $a) {
+    echo 3;
+}
+
+if (5 > $a) {
+    echo 5;
+}
+
+if (null < $a) {
+    echo "null";
+}

--- a/tests/codestyle/fixtures/yodaStyle/expected.php
+++ b/tests/codestyle/fixtures/yodaStyle/expected.php
@@ -5,3 +5,23 @@ declare(strict_types=1);
 if ($a === null) {
     echo "null";
 }
+
+if ($a === null) {
+    echo "null";
+}
+
+if ($a <= 3) {
+    echo 3;
+}
+
+if ($a >= 3) {
+    echo 3;
+}
+
+if ($a < 5) {
+    echo 5;
+}
+
+if ($a > null) {
+    echo "null";
+}

--- a/tests/codestyle/fixtures/yodaStyle/expected.php
+++ b/tests/codestyle/fixtures/yodaStyle/expected.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+if ($a === null) {
+    echo "null";
+}


### PR DESCRIPTION
This should close #69 .
**Before:**
```
<?php

if (null === $a) {
    echo "null";
}
```
**After:**
```
<?php

declare(strict_types=1);

if ($a === null) {
    echo "null";
}
```