### PR TITLE
#39 - trailing commas for match expressions

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": "^8.0",
-    "friendsofphp/php-cs-fixer": "^3.8.0",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.11.0"
+    "friendsofphp/php-cs-fixer": "^3.9.2",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.11.1"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -193,6 +193,7 @@ class CommonRules extends Rules
                 "arrays",
                 "parameters",
                 "arguments",
+                "match",
             ],
         ],
         NullableTypeDeclarationForDefaultNullValueFixer::class => true,

--- a/tests/codestyle/fixtures/trailingCommas/actual.php
+++ b/tests/codestyle/fixtures/trailingCommas/actual.php
@@ -25,4 +25,13 @@ class TrailingCommasExample
             3
         ];
     }
+
+    public function match(int $i): int
+    {
+        return match ($i) {
+            1 => 1,
+            2 => 3,
+            default => 0
+        };
+    }
 }

--- a/tests/codestyle/fixtures/trailingCommas/expected.php
+++ b/tests/codestyle/fixtures/trailingCommas/expected.php
@@ -27,4 +27,13 @@ class TrailingCommasExample
             3,
         ];
     }
+
+    public function match(int $i): int
+    {
+        return match ($i) {
+            1 => 1,
+            2 => 3,
+            default => 0,
+        };
+    }
 }


### PR DESCRIPTION
With this pull request this:

```php
return match ($i) {
    1 => 1,
    2 => 3,
    default => 0
};
```

will be transformed to this:
```php
return match ($i) {
    1 => 1,
    2 => 3,
    default => 0,
};
```

This should finally close #39.