### PR TITLE
#80 - simple to complex string variables

### DIFF
--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -81,6 +81,7 @@ use PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer;
 use PhpCsFixer\Fixer\Strict\DeclareStrictTypesFixer;
 use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
+use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
@@ -248,5 +249,6 @@ class CommonRules extends Rules
         SingleLineAfterImportsFixer::class => true,
         SingleLineCommentSpacingFixer::class => true,
         BlankLineAfterNamespaceFixer::class => true,
+        SimpleToComplexStringVariableFixer::class => true,
     ];
 }

--- a/src/Tools/CodestyleFileInitializer.php
+++ b/src/Tools/CodestyleFileInitializer.php
@@ -8,7 +8,7 @@ class CodestyleFileInitializer
 {
     public function run(string $root, string $filename = "codestyle.php"): void
     {
-        $codestyleFilePath = "${root}/${filename}";
+        $codestyleFilePath = "{$root}/{$filename}";
 
         if (file_exists($codestyleFilePath)) {
             fwrite(STDERR, "File codestyle.php already exists.\n");

--- a/src/Tools/ComposerManifestScriptsInitializer.php
+++ b/src/Tools/ComposerManifestScriptsInitializer.php
@@ -8,7 +8,7 @@ class ComposerManifestScriptsInitializer
 {
     public function run(string $root): void
     {
-        $composerManifestFile = "${root}/composer.json";
+        $composerManifestFile = "{$root}/composer.json";
 
         $hasComposerFileChanged = false;
         $composer = json_decode(file_get_contents($composerManifestFile), associative: true);
@@ -19,10 +19,10 @@ class ComposerManifestScriptsInitializer
 
         foreach ($scripts as $command => $script) {
             if (isset($composer["scripts"][$command])) {
-                fwrite(STDOUT, "Script ${command} is already declared.\n");
+                fwrite(STDOUT, "Script {$command} is already declared.\n");
             } else {
                 $composer["scripts"][$command] = $script;
-                fwrite(STDOUT, "Script ${command} has been added to composer.json file.\n");
+                fwrite(STDOUT, "Script {$command} has been added to composer.json file.\n");
                 $hasComposerFileChanged = true;
             }
         }

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -76,7 +76,7 @@ class CodestyleTest extends TestCase
         $application->setAutoExit(false);
 
         $output = new BufferedOutput();
-        $result = $application->run(new StringInput("fix ${dryRun} --diff --config ./tests/codestyle/config.php"), $output);
+        $result = $application->run(new StringInput("fix {$dryRun} --diff --config ./tests/codestyle/config.php"), $output);
 
         return $result === 0;
     }
@@ -86,22 +86,22 @@ class CodestyleTest extends TestCase
      */
     protected function testFixture(string $name): void
     {
-        copy(__DIR__ . "/fixtures/${name}/actual.php", __DIR__ . "/tmp/${name}.php");
+        copy(__DIR__ . "/fixtures/{$name}/actual.php", __DIR__ . "/tmp/{$name}.php");
 
         $this->assertFalse(
             $this->runFixer(),
-            "Fixture fixtures/${name} returned invalid true result.",
+            "Fixture fixtures/{$name} returned invalid true result.",
         );
 
         $this->assertTrue(
             $this->runFixer(fix: true),
-            "Fixture fixtures/${name} was not proceeded properly.",
+            "Fixture fixtures/{$name} was not proceeded properly.",
         );
 
         $this->assertFileEquals(
-            __DIR__ . "/fixtures/${name}/expected.php",
-            __DIR__ . "/tmp/${name}.php",
-            "Result of proceeded fixture fixtures/${name} is not equal to expected.",
+            __DIR__ . "/fixtures/{$name}/expected.php",
+            __DIR__ . "/tmp/{$name}.php",
+            "Result of proceeded fixture fixtures/{$name} is not equal to expected.",
         );
     }
 

--- a/tests/codestyle/fixtures/stringVariables/actual.php
+++ b/tests/codestyle/fixtures/stringVariables/actual.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$test = "test";
+$concat = "test $test test";
+$legacy = "Hello ${test}!";

--- a/tests/codestyle/fixtures/stringVariables/expected.php
+++ b/tests/codestyle/fixtures/stringVariables/expected.php
@@ -1,0 +1,7 @@
+<?php
+
+declare(strict_types=1);
+
+$test = "test";
+$concat = "test $test test";
+$legacy = "Hello {$test}!";

--- a/tests/codestyle/fixtures/trailingCommas/actual.php
+++ b/tests/codestyle/fixtures/trailingCommas/actual.php
@@ -14,7 +14,7 @@ class TrailingCommasExample
         string $a,
         string $b
     ): string {
-        return "${a}-${b}";
+        return "{$a}-{$b}";
     }
 
     public function testArrays(): array

--- a/tests/codestyle/fixtures/trailingCommas/expected.php
+++ b/tests/codestyle/fixtures/trailingCommas/expected.php
@@ -16,7 +16,7 @@ class TrailingCommasExample
         string $a,
         string $b,
     ): string {
-        return "${a}-${b}";
+        return "{$a}-{$b}";
     }
 
     public function testArrays(): array


### PR DESCRIPTION
As `"Hello ${test}!"` syntax will be deprecated in PHP8.2, I added a rule to remove it from our codebase.

It will be a little pain in the ass, because before the release 1.3.0 the old syntax was a default style for inline string interpolation. Be ready for multiple files changed in all projects.

This closes #80 and it's connected to #68.