### PR TITLE
#11 - anonymous functions spacing

### DIFF
--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -245,6 +245,7 @@ class CommonRules extends Rules
         ObjectOperatorWithoutWhitespaceFixer::class => true,
         FunctionDeclarationFixer::class => [
             "closure_function_spacing" => "none",
+            "closure_fn_spacing" => "none",
         ],
         SingleLineAfterImportsFixer::class => true,
         SingleLineCommentSpacingFixer::class => true,


### PR DESCRIPTION
With https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6658 PHP CS Fixer broke default spacing for `fn()`s. This PR returns it.

It's again connected to #11.