### PR TITLE
#73 - printing number of checked files

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ["8.0", "8.1"]
+        php: ["8.0", "8.1", "8.2"]
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ["8.0", "8.1", "8.2"]
+        php: ["8.0", "8.1"]
 
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": "^8.0",
-    "friendsofphp/php-cs-fixer": "^3.9.2",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.11.1"
+    "friendsofphp/php-cs-fixer": "^3.13.1",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.11.3"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",


### PR DESCRIPTION
With my changes from https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/6674 the number of checked/to-be-fixed files should be displayed in your console:

```
dcr php composer cs
Creating codestyle_php_run ... done
> ./vendor/bin/php-cs-fixer fix --dry-run --diff --config codestyle.php
Loaded config Blumilk codestyle standard from "codestyle.php".

Found 0 of 18 files that can be fixed in 0.542 seconds, 16.000 MB memory used
```

This should close #73.