### PR TITLE
#85 - drop PHP 8.0 support

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -13,7 +13,7 @@ jobs:
 
     strategy:
       matrix:
-        php: ["8.0", "8.1"]
+        php: ["8.1", "8.2"]
 
     steps:
       - uses: actions/checkout@v2

--- a/composer.json
+++ b/composer.json
@@ -4,9 +4,9 @@
   "license": "MIT",
   "type": "library",
   "require": {
-    "php": "^8.0",
-    "friendsofphp/php-cs-fixer": "^3.13.1",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.11.3"
+    "php": "^8.1",
+    "friendsofphp/php-cs-fixer": "^3.15",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.13"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: "3.7"
 
 services:
   php:
-    image: ghcr.io/blumilksoftware/php:8.1.0.0
+    image: ghcr.io/blumilksoftware/php:8.2
     container_name: blumilk-codestyle-php
     working_dir: /application
     user: ${CURRENT_UID:-1000}

--- a/src/Configuration/Defaults/LaravelPaths.php
+++ b/src/Configuration/Defaults/LaravelPaths.php
@@ -8,8 +8,9 @@ class LaravelPaths extends Paths
 {
     public const LARAVEL_8_PATHS = ["app", "bootstrap/app.php", "config", "database", "public/index.php", "resources/lang", "routes", "tests"];
     public const LARAVEL_9_PATHS = ["app", "bootstrap/app.php", "config", "database", "lang", "public/index.php", "routes", "tests"];
+    public const LARAVEL_10_PATHS = self::LARAVEL_9_PATHS;
 
-    public function __construct(array $paths = self::LARAVEL_9_PATHS)
+    public function __construct(array $paths = self::LARAVEL_10_PATHS)
     {
         parent::__construct(...$paths);
     }

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -66,6 +66,21 @@ class CodestyleTest extends TestCase
     }
 
     /**
+     * @requires PHP >= 8.2
+     * @throws Exception
+     */
+    public function testPhp82Fixtures(): void
+    {
+        $fixtures = [
+            "php82",
+        ];
+
+        foreach ($fixtures as $fixture) {
+            $this->testFixture($fixture);
+        }
+    }
+
+    /**
      * @throws Exception
      */
     protected function runFixer(bool $fix = false): bool

--- a/tests/codestyle/fixtures/php82/actual.php
+++ b/tests/codestyle/fixtures/php82/actual.php
@@ -1,0 +1,26 @@
+<?php
+
+readonly class Php82
+{
+    use Usable;
+
+    public function always(): true
+    {
+        return true;
+    }
+
+    public function never(): false
+    {
+        return false;
+    }
+
+    public function null(): null
+    {
+        return null;
+    }
+}
+
+trait Usable
+{
+    public const X = "x";
+}

--- a/tests/codestyle/fixtures/php82/expected.php
+++ b/tests/codestyle/fixtures/php82/expected.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+readonly class Php82
+{
+    use Usable;
+
+    public function always(): true
+    {
+        return true;
+    }
+
+    public function never(): false
+    {
+        return false;
+    }
+
+    public function null(): null
+    {
+        return null;
+    }
+}
+
+trait Usable
+{
+    public const X = "x";
+}


### PR DESCRIPTION
As PH 8.0 lost its active support with November 2022, we finally dropping support for that version in our Codestyle. Additionally authors of PHP-CS-Fixer finally released 3.15 with PHP 8.2 support, so our package should handle newest PHP in our projects.

This should close #85.