### PR TITLE
- common ruleset update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,7 +10,7 @@
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",
-    "phpunit/phpunit": "^9.5",
+    "phpunit/phpunit": "^10.0",
     "symfony/console": "^6.0"
   },
   "authors": [
@@ -33,7 +33,7 @@
     "csf": "./vendor/bin/php-cs-fixer fix --diff --config codestyle.php",
     "test": "./vendor/bin/phpunit tests --colors always",
     "unit": "./vendor/bin/phpunit tests/unit --colors always",
-    "e2e": "./vendor/bin/phpunit tests/codestyle --colors always"
+    "e2e": "./vendor/bin/phpunit tests/codestyle --display-deprecations --colors always"
   },
   "bin": [
     "bin/codestyle"

--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     "csf": "./vendor/bin/php-cs-fixer fix --diff --config codestyle.php",
     "test": "./vendor/bin/phpunit tests --colors always",
     "unit": "./vendor/bin/phpunit tests/unit --colors always",
-    "e2e": "./vendor/bin/phpunit tests/codestyle --display-deprecations --colors always"
+    "e2e": "./vendor/bin/phpunit tests/codestyle --colors always"
   },
   "bin": [
     "bin/codestyle"

--- a/readme.md
+++ b/readme.md
@@ -101,16 +101,8 @@ or following to fix found errors:
 composer csf
 ```
 
-#### Upgrading guide from 0.x
-With version 1.x we removed `symplify/easy-coding-standard` dependency in the project. The checklist for updating old projects is as follows:
-
-- [ ] update the main dependency `blumilksoftware/codestyle` to version `^1.0` in `composer.json` file
-- [ ] run `composer update blumilksoftware/codestyle -W`
-- [ ] rename `ecs.php` to `codestyle.php`
-- [ ] update scripts in `composer.json` file
-- [ ] update scripts in Github Actions
-- [ ] the constructor of `Blumilk\Codestyle\Config` lost two parameters: `$sets` and `$skipped`; all manipulations of rules should be done on base `$rules` list
-- [ ] `Blumilk\Codestyle\Configuration\Defaults\LaravelPaths` returns a default Laravel 9 directory schema; for Laravel 8 additional parameter `LaravelPaths::LARAVEL_8_PATHS` should be added
+#### Upgrading guide
+Upgrading guide is available in [upgrading.md](./upgrading.md) file.
 
 ### Contributing
 In cloned or forked repository, run:

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -7,13 +7,15 @@ namespace Blumilk\Codestyle\Configuration\Defaults;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoLaravelMigrationsGeneratedCommentFixer;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
-use PhpCsFixer\Fixer\ArrayNotation\NoTrailingCommaInSinglelineArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer;
 use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
 use PhpCsFixer\Fixer\Basic\BracesFixer;
+use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
 use PhpCsFixer\Fixer\Casing\LowercaseStaticReferenceFixer;
 use PhpCsFixer\Fixer\Casing\MagicConstantCasingFixer;
+use PhpCsFixer\Fixer\Casing\MagicMethodCasingFixer;
+use PhpCsFixer\Fixer\Casing\NativeFunctionCasingFixer;
 use PhpCsFixer\Fixer\CastNotation\CastSpacesFixer;
 use PhpCsFixer\Fixer\CastNotation\LowercaseCastFixer;
 use PhpCsFixer\Fixer\CastNotation\ShortScalarCastFixer;
@@ -25,6 +27,7 @@ use PhpCsFixer\Fixer\ClassNotation\SelfAccessorFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleClassElementPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\SingleTraitInsertPerStatementFixer;
 use PhpCsFixer\Fixer\ClassNotation\VisibilityRequiredFixer;
+use PhpCsFixer\Fixer\Comment\NoEmptyCommentFixer;
 use PhpCsFixer\Fixer\Comment\NoTrailingWhitespaceInCommentFixer;
 use PhpCsFixer\Fixer\Comment\SingleLineCommentSpacingFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
@@ -34,6 +37,7 @@ use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionDeclarationFixer;
 use PhpCsFixer\Fixer\FunctionNotation\FunctionTypehintSpaceFixer;
+use PhpCsFixer\Fixer\FunctionNotation\LambdaNotUsedImportFixer;
 use PhpCsFixer\Fixer\FunctionNotation\MethodArgumentSpaceFixer;
 use PhpCsFixer\Fixer\FunctionNotation\NullableTypeDeclarationForDefaultNullValueFixer;
 use PhpCsFixer\Fixer\FunctionNotation\ReturnTypeDeclarationFixer;
@@ -52,9 +56,12 @@ use PhpCsFixer\Fixer\NamespaceNotation\BlankLineAfterNamespaceFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\CleanNamespaceFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\NoLeadingNamespaceWhitespaceFixer;
 use PhpCsFixer\Fixer\NamespaceNotation\SingleBlankLineBeforeNamespaceFixer;
+use PhpCsFixer\Fixer\Naming\NoHomoglyphNamesFixer;
+use PhpCsFixer\Fixer\Operator\AssignNullCoalescingToCoalesceEqualFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
 use PhpCsFixer\Fixer\Operator\NewWithBracesFixer;
+use PhpCsFixer\Fixer\Operator\NoUselessNullsafeOperatorFixer;
 use PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer;
 use PhpCsFixer\Fixer\Operator\StandardizeIncrementFixer;
 use PhpCsFixer\Fixer\Operator\TernaryOperatorSpacesFixer;
@@ -75,6 +82,9 @@ use PhpCsFixer\Fixer\PhpTag\BlankLineAfterOpeningTagFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitMethodCasingFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitSetUpTearDownVisibilityFixer;
 use PhpCsFixer\Fixer\PhpUnit\PhpUnitTestAnnotationFixer;
+use PhpCsFixer\Fixer\ReturnNotation\NoUselessReturnFixer;
+use PhpCsFixer\Fixer\ReturnNotation\SimplifiedNullReturnFixer;
+use PhpCsFixer\Fixer\Semicolon\MultilineWhitespaceBeforeSemicolonsFixer;
 use PhpCsFixer\Fixer\Semicolon\NoEmptyStatementFixer;
 use PhpCsFixer\Fixer\Semicolon\NoSinglelineWhitespaceBeforeSemicolonsFixer;
 use PhpCsFixer\Fixer\Semicolon\SpaceAfterSemicolonFixer;
@@ -84,12 +94,14 @@ use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
+use PhpCsFixer\Fixer\Whitespace\LineEndingFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoSpacesAroundOffsetFixer;
 use PhpCsFixer\Fixer\Whitespace\NoSpacesInsideParenthesisFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
+use PhpCsFixer\Fixer\Whitespace\StatementIndentationFixer;
 use PhpCsFixerCustomFixers\Fixer\CommentedOutFunctionFixer;
 use PhpCsFixerCustomFixers\Fixer\ConstructorEmptyBracesFixer;
 use PhpCsFixerCustomFixers\Fixer\MultilinePromotedPropertiesFixer;
@@ -113,14 +125,19 @@ class CommonRules extends Rules
         ArrayIndentationFixer::class => true,
         TrimArraySpacesFixer::class => true,
         WhitespaceAfterCommaInArrayFixer::class => true,
-        NoTrailingCommaInSinglelineArrayFixer::class => true,
-        ArraySyntaxFixer::class => ["syntax" => "short"],
+        ArraySyntaxFixer::class => [
+            "syntax" => "short",
+        ],
         PhpUnitMethodCasingFixer::class => true,
         FunctionToConstantFixer::class => true,
         ExplicitIndirectVariableFixer::class => true,
-        SingleClassElementPerStatementFixer::class => ["elements" => ["const", "property"]],
+        SingleClassElementPerStatementFixer::class => [
+            "elements" => ["const", "property"],
+        ],
         NewWithBracesFixer::class => true,
-        ClassDefinitionFixer::class => ["single_line" => true],
+        ClassDefinitionFixer::class => [
+            "single_line" => true,
+        ],
         StandardizeIncrementFixer::class => true,
         SelfAccessorFixer::class => true,
         MagicConstantCasingFixer::class => true,
@@ -135,14 +152,25 @@ class CommonRules extends Rules
         PhpdocTypesFixer::class => true,
         PhpdocReturnSelfReferenceFixer::class => true,
         PhpdocVarWithoutNameFixer::class => true,
-        NoSuperfluousPhpdocTagsFixer::class => ["remove_inheritdoc" => true, "allow_mixed" => true],
+        NoSuperfluousPhpdocTagsFixer::class => [
+            "remove_inheritdoc" => true,
+            "allow_mixed" => true,
+        ],
         SingleBlankLineBeforeNamespaceFixer::class => true,
         PhpUnitTestAnnotationFixer::class => true,
         PhpUnitSetUpTearDownVisibilityFixer::class => true,
         BlankLineAfterOpeningTagFixer::class => true,
         MethodChainingIndentationFixer::class => true,
-        ConcatSpaceFixer::class => ["spacing" => "one"],
-        BinaryOperatorSpacesFixer::class => ["operators" => ["=>" => "single_space", "=" => "single_space", "&" => "no_space"]],
+        ConcatSpaceFixer::class => [
+            "spacing" => "one",
+        ],
+        BinaryOperatorSpacesFixer::class => [
+            "operators" => [
+                "=>" => "single_space",
+                "=" => "single_space",
+                "&" => "no_space",
+            ],
+        ],
         SingleTraitInsertPerStatementFixer::class => true,
         FunctionTypehintSpaceFixer::class => true,
         NoBlankLinesAfterClassOpeningFixer::class => true,
@@ -183,10 +211,19 @@ class CommonRules extends Rules
         ],
         NoExtraBlankLinesFixer::class => [
             "tokens" => [
-                "extra",
+                "attribute",
+                "break",
+                "case",
+                "continue",
                 "curly_brace_block",
+                "default",
+                "extra",
                 "parenthesis_brace_block",
+                "return",
                 "square_brace_block",
+                "switch",
+                "throw",
+                "use",
             ],
         ],
         TrailingCommaInMultilineFixer::class => [
@@ -251,5 +288,18 @@ class CommonRules extends Rules
         SingleLineCommentSpacingFixer::class => true,
         BlankLineAfterNamespaceFixer::class => true,
         SimpleToComplexStringVariableFixer::class => true,
+        NoEmptyCommentFixer::class => true,
+        NoTrailingCommaInSinglelineFixer::class => true,
+        MagicMethodCasingFixer::class => true,
+        NativeFunctionCasingFixer::class => true,
+        LambdaNotUsedImportFixer::class => true,
+        NoHomoglyphNamesFixer::class => true,
+        AssignNullCoalescingToCoalesceEqualFixer::class => true,
+        NoUselessNullsafeOperatorFixer::class => true,
+        NoUselessReturnFixer::class => true,
+        SimplifiedNullReturnFixer::class => true,
+        MultilineWhitespaceBeforeSemicolonsFixer::class => true,
+        LineEndingFixer::class => true,
+        StatementIndentationFixer::class => true,
     ];
 }

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -20,83 +20,75 @@ class CodestyleTest extends TestCase
     }
 
     /**
+     * @dataProvider providePhp80Fixtures
      * @requires PHP >= 8.0
      * @throws Exception
      */
-    public function testPhp80Fixtures(): void
+    public function testPhp80Fixtures(string $name): void
     {
-        $fixtures = [
-            "noExtraBlankLines",
-            "nullableTypeForDefaultNull",
-            "operatorSpacing",
-            "singleQuotes",
-            "strictTypes",
-            "trailingCommas",
-            "unionTypes",
-            "references",
-            "classAttributesSeparation",
-            "uselessParenthesis",
-            "laravelMigrations",
-            "phpdocs",
-            "yodaStyle",
-            "objectOperators",
-            "anonymousFunctions",
-            "namespaces",
-        ];
-
-        foreach ($fixtures as $fixture) {
-            $this->testFixture($fixture);
-        }
+        $this->testFixture($name);
     }
 
     /**
+     * @dataProvider providePhp81Fixtures
      * @requires PHP >= 8.1
      * @throws Exception
      */
-    public function testPhp81Fixtures(): void
+    public function testPhp81Fixtures(string $name): void
     {
-        $fixtures = [
-            "enums",
-            "readonlies",
-        ];
-
-        foreach ($fixtures as $fixture) {
-            $this->testFixture($fixture);
-        }
+        $this->testFixture($name);
     }
 
     /**
+     * @dataProvider providePhp82Fixtures
      * @requires PHP >= 8.2
      * @throws Exception
      */
-    public function testPhp82Fixtures(): void
+    public function testPhp82Fixtures(string $name): void
     {
-        $fixtures = [
-            "php82",
+        $this->testFixture($name);
+    }
+
+    public static function providePhp80Fixtures(): array
+    {
+        return [
+            ["noExtraBlankLines"],
+            ["nullableTypeForDefaultNull"],
+            ["operatorSpacing"],
+            ["singleQuotes"],
+            ["strictTypes"],
+            ["trailingCommas"],
+            ["unionTypes"],
+            ["references"],
+            ["classAttributesSeparation"],
+            ["uselessParenthesis"],
+            ["laravelMigrations"],
+            ["phpdocs"],
+            ["yodaStyle"],
+            ["objectOperators"],
+            ["anonymousFunctions"],
+            ["namespaces"],
+            ["emptyLines"],
         ];
-
-        foreach ($fixtures as $fixture) {
-            $this->testFixture($fixture);
-        }
     }
 
-    /**
-     * @throws Exception
-     */
-    protected function runFixer(bool $fix = false): bool
+    public static function providePhp81Fixtures(): array
     {
-        $dryRun = $fix ? "" : "--dry-run";
+        return [
+            ["enums"],
+            ["readonlies"],
+        ];
+    }
 
-        $application = new Application();
-        $application->setAutoExit(false);
-
-        $output = new BufferedOutput();
-        $result = $application->run(new StringInput("fix {$dryRun} --diff --config ./tests/codestyle/config.php"), $output);
-
-        return $result === 0;
+    public static function providePhp82Fixtures(): array
+    {
+        return [
+            ["php82"],
+        ];
     }
 
     /**
+     * @dataProvider providePhp80Fixtures
      * @throws Exception
      */
     protected function testFixture(string $name): void
@@ -118,6 +110,22 @@ class CodestyleTest extends TestCase
             __DIR__ . "/tmp/{$name}.php",
             "Result of proceeded fixture fixtures/{$name} is not equal to expected.",
         );
+    }
+
+    /**
+     * @throws Exception
+     */
+    protected function runFixer(bool $fix = false): bool
+    {
+        $dryRun = $fix ? "" : "--dry-run";
+
+        $application = new Application();
+        $application->setAutoExit(false);
+
+        $output = new BufferedOutput();
+        $result = $application->run(new StringInput("fix {$dryRun} --diff --config ./tests/codestyle/config.php"), $output);
+
+        return $result === 0;
     }
 
     protected function clearTempDirectory(): void

--- a/tests/codestyle/fixtures/emptyLines/actual.php
+++ b/tests/codestyle/fixtures/emptyLines/actual.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    "default" => env("DB_CONNECTION", "mysql"),
+
+
+    "connections" => [
+        "sqlite" => [
+            "driver" => "sqlite",
+            "url" => env("DATABASE_URL"),
+            "database" => env("DB_DATABASE", database_path("database.sqlite")),
+            "prefix" => "",
+            "foreign_key_constraints" => env("DB_FOREIGN_KEYS", true),
+        ],
+    ]
+];

--- a/tests/codestyle/fixtures/emptyLines/expected.php
+++ b/tests/codestyle/fixtures/emptyLines/expected.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+return [
+    "default" => env("DB_CONNECTION", "mysql"),
+
+    "connections" => [
+        "sqlite" => [
+            "driver" => "sqlite",
+            "url" => env("DATABASE_URL"),
+            "database" => env("DB_DATABASE", database_path("database.sqlite")),
+            "prefix" => "",
+            "foreign_key_constraints" => env("DB_FOREIGN_KEYS", true),
+        ],
+    ],
+];

--- a/tests/codestyle/fixtures/objectOperators/expected.php
+++ b/tests/codestyle/fixtures/objectOperators/expected.php
@@ -10,7 +10,7 @@ class ObjectOperatorTest
     public function get(): void
     {
         $array = $this->array;
-        if ($this?->nullable) {
+        if ($this->nullable) {
             unset($array);
         }
     }

--- a/upgrading.md
+++ b/upgrading.md
@@ -1,0 +1,16 @@
+### Upgrading guide from 1.x to 2.x
+The checklist for updating old projects is as follows:
+
+- [ ] update the main dependency `blumilksoftware/codestyle` to version `^2.0` in `composer.json` file
+- [ ] run `composer update blumilksoftware/codestyle -W`
+
+### Upgrading guide from 0.x to 1.x
+With version 1.x we removed `symplify/easy-coding-standard` dependency in the project. The checklist for updating old projects is as follows:
+
+- [ ] update the main dependency `blumilksoftware/codestyle` to version `^1.0` in `composer.json` file
+- [ ] run `composer update blumilksoftware/codestyle -W`
+- [ ] rename `ecs.php` to `codestyle.php`
+- [ ] update scripts in `composer.json` file
+- [ ] update scripts in Github Actions
+- [ ] the constructor of `Blumilk\Codestyle\Config` lost two parameters: `$sets` and `$skipped`; all manipulations of rules should be done on base `$rules` list
+- [ ] `Blumilk\Codestyle\Configuration\Defaults\LaravelPaths` returns a default Laravel 9 directory schema; for Laravel 8 additional parameter `LaravelPaths::LARAVEL_8_PATHS` should be added


### PR DESCRIPTION
I added new fixers to common ruleset:

* [no_empty_comment](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:no_empty_comment)
* [no_trailing_comma_in_singleline](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:no_trailing_comma_in_singleline)
* [magic_method_casing](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:magic_method_casing)
* [native_function_casing](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:native_function_casing)
* [lambda_not_used_import](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:lambda_not_used_import)
* [no_homoglyph_names](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:no_homoglyph_names)
* [assign_null_coalescing_to_coalesce_equal](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:assign_null_coalescing_to_coalesce_equal)
* [no_useless_nullsafe_operator](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:no_useless_nullsafe_operator)
* [no_useless_return](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:no_useless_return)
* [simplified_null_return](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:simplified_null_return)
* [multiline_whitespace_before_semicolons](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:multiline_whitespace_before_semicolons)
* [line_ending](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:line_ending)
* [statement_indentation](https://mlocati.github.io/php-cs-fixer-configurator/#version:3.15|fixer:statement_indentation)

I am open to discuss all proposed rules.

I refactored tests a little to use PHPUnit data providers.