### PR TITLE
#91 - ordering and grouping imports

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": "^8.1",
-    "friendsofphp/php-cs-fixer": "^3.15",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.13"
+    "friendsofphp/php-cs-fixer": "^3.16",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.14"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -10,7 +10,6 @@ use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer;
 use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
-use PhpCsFixer\Fixer\Basic\BracesFixer;
 use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
 use PhpCsFixer\Fixer\Casing\LowercaseStaticReferenceFixer;
 use PhpCsFixer\Fixer\Casing\MagicConstantCasingFixer;
@@ -276,7 +275,6 @@ class CommonRules extends Rules
         PhpdocNoIncorrectVarAnnotationFixer::class => true,
         PhpdocNoSuperfluousParamFixer::class => true,
         PhpdocParamOrderFixer::class => true,
-        BracesFixer::class => true,
         NoSpacesInsideParenthesisFixer::class => true,
         YodaStyleFixer::class => [
             "equal" => false,

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -93,6 +93,7 @@ use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBetweenImportGroupsFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
 use PhpCsFixer\Fixer\Whitespace\LineEndingFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
@@ -198,7 +199,10 @@ class CommonRules extends Rules
         VoidReturnFixer::class => true,
         UseArrowFunctionsFixer::class => true,
         FullyQualifiedStrictTypesFixer::class => true,
-        OrderedImportsFixer::class => true,
+        OrderedImportsFixer::class => [
+            "sort_algorithm" => "alpha",
+            "imports_order" => ["const", "class", "function"],
+        ],
         PhpdocLineSpanFixer::class => [
             "const" => "single",
             "property" => "single",
@@ -301,5 +305,6 @@ class CommonRules extends Rules
         MultilineWhitespaceBeforeSemicolonsFixer::class => true,
         LineEndingFixer::class => true,
         StatementIndentationFixer::class => true,
+        BlankLineBetweenImportGroupsFixer::class => true,
     ];
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -200,7 +200,7 @@ class CommonRules extends Rules
         FullyQualifiedStrictTypesFixer::class => true,
         OrderedImportsFixer::class => [
             "sort_algorithm" => "alpha",
-            "imports_order" => ["const", "class", "function"],
+            "imports_order" => ["class", "function", "const"],
         ],
         PhpdocLineSpanFixer::class => [
             "const" => "single",

--- a/tests/codestyle/CodestyleTest.php
+++ b/tests/codestyle/CodestyleTest.php
@@ -69,6 +69,7 @@ class CodestyleTest extends TestCase
             ["anonymousFunctions"],
             ["namespaces"],
             ["emptyLines"],
+            ["importsOrder"],
         ];
     }
 

--- a/tests/codestyle/fixtures/importsOrder/actual.php
+++ b/tests/codestyle/fixtures/importsOrder/actual.php
@@ -6,6 +6,7 @@ use function array_merge;
 use function assert;
 use Something\Api;
 use Something\Paths;
+use const Something\CONSTANT;
 use Whatever\File;
 
 use Whatever\SpecificationFile;
@@ -18,7 +19,7 @@ class Merge
         $merge = array_merge($a, $b);
 
         $reader = new Reader(new SpecificationFile(new File()), new Paths());
-        $result = $reader->merge($merge, new Api());
+        $result = $reader->merge($merge, new Api(), flag: CONSTANT);
 
         assert($result);
     }

--- a/tests/codestyle/fixtures/importsOrder/actual.php
+++ b/tests/codestyle/fixtures/importsOrder/actual.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use function array_merge;
+use function assert;
+use Something\Api;
+use Something\Paths;
+use Whatever\File;
+
+use Whatever\SpecificationFile;
+use Whatever\Reader;
+
+class Merge
+{
+    public function do(array $a, array $b): void
+    {
+        $merge = array_merge($a, $b);
+
+        $reader = new Reader(new SpecificationFile(new File()), new Paths());
+        $result = $reader->merge($merge, new Api());
+
+        assert($result);
+    }
+}

--- a/tests/codestyle/fixtures/importsOrder/expected.php
+++ b/tests/codestyle/fixtures/importsOrder/expected.php
@@ -1,0 +1,25 @@
+<?php
+
+declare(strict_types=1);
+
+use Something\Api;
+use Something\Paths;
+use Whatever\File;
+use Whatever\Reader;
+use Whatever\SpecificationFile;
+
+use function array_merge;
+use function assert;
+
+class Merge
+{
+    public function do(array $a, array $b): void
+    {
+        $merge = array_merge($a, $b);
+
+        $reader = new Reader(new SpecificationFile(new File()), new Paths());
+        $result = $reader->merge($merge, new Api());
+
+        assert($result);
+    }
+}

--- a/tests/codestyle/fixtures/importsOrder/expected.php
+++ b/tests/codestyle/fixtures/importsOrder/expected.php
@@ -11,6 +11,8 @@ use Whatever\SpecificationFile;
 use function array_merge;
 use function assert;
 
+use const Something\CONSTANT;
+
 class Merge
 {
     public function do(array $a, array $b): void
@@ -18,7 +20,7 @@ class Merge
         $merge = array_merge($a, $b);
 
         $reader = new Reader(new SpecificationFile(new File()), new Paths());
-        $result = $reader->merge($merge, new Api());
+        $result = $reader->merge($merge, new Api(), flag: CONSTANT);
 
         assert($result);
     }


### PR DESCRIPTION
In another project I found out that codestyle is not checking imports ordering and grouping properly.

With this pull request these imports:
```php
use function array_merge;
use function assert;
use Something\Api;
use Something\Paths;
use const Something\CONSTANT;
use Whatever\File;

use Whatever\SpecificationFile;
use Whatever\Reader;
```

will look like [PSR-12 guideline](https://www.php-fig.org/psr/psr-12/#3-declare-statements-namespace-and-import-statements):
```php
use Something\Api;
use Something\Paths;
use Whatever\File;
use Whatever\Reader;
use Whatever\SpecificationFile;

use function array_merge;
use function assert;

use const Something\CONSTANT;
```

So this pull request:
* should close #91 
* updates dependencies
* changes the way the imports are sorted and grouped
* removes deprecated `PhpCsFixer\Fixer\Basic\BracesFixer`