### PR TITLE
#94 - return statement missing blank line fixer

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -76,6 +76,7 @@ class Config
             if (str_ends_with($path, ".php")) {
                 $paths[] = $path;
             }
+
             return;
         }
 

--- a/src/Config.php
+++ b/src/Config.php
@@ -38,6 +38,7 @@ class Config
         list("paths" => $paths, "rules" => $rules) = $this->options();
 
         $files = [];
+
         foreach ($paths as $path) {
             $directory = $this->rootPath . "/" . $path;
             $this->getAllFiles($files, $directory);

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -92,6 +92,7 @@ use PhpCsFixer\Fixer\Strict\StrictComparisonFixer;
 use PhpCsFixer\Fixer\Strict\StrictParamFixer;
 use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
+use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBetweenImportGroupsFixer;
 use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
 use PhpCsFixer\Fixer\Whitespace\LineEndingFixer;
@@ -304,5 +305,6 @@ class CommonRules extends Rules
         LineEndingFixer::class => true,
         StatementIndentationFixer::class => true,
         BlankLineBetweenImportGroupsFixer::class => true,
+        BlankLineBeforeStatementFixer::class => true,
     ];
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -305,6 +305,19 @@ class CommonRules extends Rules
         LineEndingFixer::class => true,
         StatementIndentationFixer::class => true,
         BlankLineBetweenImportGroupsFixer::class => true,
-        BlankLineBeforeStatementFixer::class => true,
+        BlankLineBeforeStatementFixer::class => [
+            "statements" => [
+                "break",
+                "continue",
+                "declare",
+                "return",
+                "throw",
+                "try",
+                "if",
+                "do",
+                "for",
+                "foreach",
+                "while",
+            ]],
     ];
 }

--- a/src/Configuration/Defaults/Rules.php
+++ b/src/Configuration/Defaults/Rules.php
@@ -15,6 +15,7 @@ abstract class Rules implements RulesContract
     public function get(): array
     {
         $rules = [];
+
         foreach ($this->rules as $fixer => $options) {
             /** @var AbstractFixer $fixer */
             $fixer = new $fixer();

--- a/src/Fixers/DoubleQuoteFixer.php
+++ b/src/Fixers/DoubleQuoteFixer.php
@@ -69,6 +69,7 @@ EOF;
 
             $content = $token->getContent();
             $prefix = "";
+
             if (
                 $content[0] === "'" &&
                 !str_contains($content, '"') &&

--- a/src/Fixers/NoCommentFixer.php
+++ b/src/Fixers/NoCommentFixer.php
@@ -49,6 +49,7 @@ EOF;
     public function getPriority(): int
     {
         $fixer = new NoExtraBlankLinesFixer();
+
         return $fixer->getPriority() + 1;
     }
 

--- a/src/Fixers/NoLaravelMigrationsGeneratedCommentFixer.php
+++ b/src/Fixers/NoLaravelMigrationsGeneratedCommentFixer.php
@@ -67,6 +67,7 @@ EOF;
     public function getPriority(): int
     {
         $fixer = new VoidReturnFixer();
+
         return $fixer->getPriority() + 1;
     }
 

--- a/tests/codestyle/CommonRulesetTest.php
+++ b/tests/codestyle/CommonRulesetTest.php
@@ -56,6 +56,7 @@ class CommonRulesetTest extends CodestyleTestCase
             ["namespaces"],
             ["emptyLines"],
             ["importsOrder"],
+            ["blankLineBeforeStatement"],
         ];
     }
 

--- a/tests/codestyle/fixtures/blankLineBeforeStatement/actual.php
+++ b/tests/codestyle/fixtures/blankLineBeforeStatement/actual.php
@@ -1,11 +1,26 @@
 <?php
-
 declare(strict_types=1);
 
 class BlankLine
 {
-    public function getFoo(int $foo): int {
+    /**
+     * @throws Exception
+     */
+    public function getFoo(int $foo): int
+    {
         $bar = $foo;
+        try {
+
+            while ($bar > 0) {
+                $bar++;
+            }
+            for ($i = 0; $i < 5; $i++) {
+                echo $i;
+            }
+        } catch (Exception $exception) {
+            $value = "error";
+            throw new Exception(message: $value);
+        }
         return $bar;
     }
 }

--- a/tests/codestyle/fixtures/blankLineBeforeStatement/actual.php
+++ b/tests/codestyle/fixtures/blankLineBeforeStatement/actual.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+class BlankLine
+{
+    public function getFoo(int $foo): int {
+        $bar = $foo;
+        return $bar;
+    }
+}

--- a/tests/codestyle/fixtures/blankLineBeforeStatement/actual.php
+++ b/tests/codestyle/fixtures/blankLineBeforeStatement/actual.php
@@ -23,4 +23,11 @@ class BlankLine
         }
         return $bar;
     }
+
+    protected function getBar(int $number): void
+    {
+        if ($number === 1) {
+            return;
+        }
+    }
 }

--- a/tests/codestyle/fixtures/blankLineBeforeStatement/expected.php
+++ b/tests/codestyle/fixtures/blankLineBeforeStatement/expected.php
@@ -27,4 +27,11 @@ class BlankLine
 
         return $bar;
     }
+
+    protected function getBar(int $number): void
+    {
+        if ($number === 1) {
+            return;
+        }
+    }
 }

--- a/tests/codestyle/fixtures/blankLineBeforeStatement/expected.php
+++ b/tests/codestyle/fixtures/blankLineBeforeStatement/expected.php
@@ -4,8 +4,26 @@ declare(strict_types=1);
 
 class BlankLine
 {
-    public function getFoo(int $foo): int {
+    /**
+     * @throws Exception
+     */
+    public function getFoo(int $foo): int
+    {
         $bar = $foo;
+
+        try {
+            while ($bar > 0) {
+                $bar++;
+            }
+
+            for ($i = 0; $i < 5; $i++) {
+                echo $i;
+            }
+        } catch (Exception $exception) {
+            $value = "error";
+
+            throw new Exception(message: $value);
+        }
 
         return $bar;
     }

--- a/tests/codestyle/fixtures/blankLineBeforeStatement/expected.php
+++ b/tests/codestyle/fixtures/blankLineBeforeStatement/expected.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+class BlankLine
+{
+    public function getFoo(int $foo): int {
+        $bar = $foo;
+
+        return $bar;
+    }
+}

--- a/tests/codestyle/fixtures/nullableTypeForDefaultNull/expected.php
+++ b/tests/codestyle/fixtures/nullableTypeForDefaultNull/expected.php
@@ -7,6 +7,7 @@ class NullableTypeForDefaultNull
     public function getNameLabel(string $name, ?string $title = null): string
     {
         $label = $name;
+
         if ($title !== null) {
             $label .= " " . $title;
         }

--- a/tests/codestyle/fixtures/objectOperators/expected.php
+++ b/tests/codestyle/fixtures/objectOperators/expected.php
@@ -10,6 +10,7 @@ class ObjectOperatorTest
     public function get(): void
     {
         $array = $this->array;
+
         if ($this->nullable) {
             unset($array);
         }


### PR DESCRIPTION
This should close #94.

With these changes this:
```
    public function getFoo(int $foo): int {
        $bar = $foo;
        return $bar;
    }
```
will be fixed into:
```
    public function getFoo(int $foo): int {
        $bar = $foo;

        return $bar;
    }
```