### PR TITLE
#105 - array no multiline whitespace

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -36,9 +36,9 @@
   "scripts": {
     "cs": "./vendor/bin/php-cs-fixer fix --dry-run --diff --config codestyle.php",
     "csf": "./vendor/bin/php-cs-fixer fix --diff --config codestyle.php",
-    "test": "./vendor/bin/phpunit tests --colors always",
-    "unit": "./vendor/bin/phpunit tests/unit --colors always",
-    "e2e": "./vendor/bin/phpunit tests/codestyle --colors always"
+    "test": "./vendor/bin/phpunit tests --colors=always",
+    "unit": "./vendor/bin/phpunit tests/unit --colors=always",
+    "e2e": "./vendor/bin/phpunit tests/codestyle --colors=always"
   },
   "bin": [
     "bin/codestyle"

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -7,6 +7,7 @@ namespace Blumilk\Codestyle\Configuration\Defaults;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NoLaravelMigrationsGeneratedCommentFixer;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
+use PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer;
 use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
@@ -330,5 +331,6 @@ class CommonRules extends Rules
             "anonymous_functions_opening_brace" => "same_line",
         ],
         LowercaseKeywordsFixer::class => true,
+        NoMultilineWhitespaceAroundDoubleArrowFixer::class => true,
     ];
 }

--- a/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/actual.php
+++ b/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/actual.php
@@ -1,0 +1,11 @@
+<?php
+
+class NoMultilineWhitespaceAroundDoubleArrow
+{
+    public function getArray(): array
+    {
+        return [
+
+        ];
+    }
+}

--- a/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/actual.php
+++ b/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/actual.php
@@ -2,10 +2,23 @@
 
 class NoMultilineWhitespaceAroundDoubleArrow
 {
-    public function getArray(): array
+    public function getArray1(): array
     {
         return [
 
         ];
+    }
+
+    public function getArray2(): array
+    {
+        return [1
+
+        => 2];
+    }
+
+    public function getClosure(): Closure
+    {
+        return fn() =>
+            [];
     }
 }

--- a/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/expected.php
+++ b/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/expected.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+class NoMultilineWhitespaceAroundDoubleArrow
+{
+    public function getArray(): array
+    {
+        return [];
+    }
+}

--- a/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/expected.php
+++ b/tests/fixtures/noMultilineWhitespaceAroundDoubleArrow/expected.php
@@ -4,8 +4,18 @@ declare(strict_types=1);
 
 class NoMultilineWhitespaceAroundDoubleArrow
 {
-    public function getArray(): array
+    public function getArray1(): array
     {
         return [];
+    }
+
+    public function getArray2(): array
+    {
+        return [1 => 2];
+    }
+
+    public function getClosure(): Closure
+    {
+        return fn() => [];
     }
 }


### PR DESCRIPTION
This should close #105.

Actual:

```
    public function getArray1(): array
    {
        return [

        ];
    }

    public function getArray2(): array
    {
        return [1

        => 2];
    }

    public function getClosure(): Closure
    {
        return fn() =>
            [];
    }
```

Expected:

```
    public function getArray1(): array
    {
        return [];
    }

    public function getArray2(): array
    {
        return [1 => 2];
    }

    public function getClosure(): Closure
    {
        return fn() => [];
    }
```

Fixed in `composer.json` scripts for running tests. From `--colors always` to `--colors=always`.