### PR TITLE
- importing FQCNs

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": "^8.1",
-    "friendsofphp/php-cs-fixer": "^3.48",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.19"
+    "friendsofphp/php-cs-fixer": "^3.49",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.20"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -5,8 +5,8 @@
   "type": "library",
   "require": {
     "php": "^8.1",
-    "friendsofphp/php-cs-fixer": "^3.23",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.16"
+    "friendsofphp/php-cs-fixer": "^3.48",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.19"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.0",

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,6 +23,10 @@ class Config
     protected Paths $paths;
     protected Rules $rules;
     protected string $rootPath;
+    /**
+     * @var true
+     */
+    protected bool $withoutRiskyFixers = false;
 
     public function __construct(
         ?Paths $paths = null,
@@ -52,7 +56,7 @@ class Config
             ->setUsingCache(false)
             ->registerCustomFixers(new PhpCsFixerCustomFixers())
             ->registerCustomFixers($this->getCustomFixers())
-            ->setRiskyAllowed(true)
+            ->setRiskyAllowed($this->withoutRiskyFixers)
             ->setRules($rules);
     }
 
@@ -68,6 +72,13 @@ class Config
     public function purgeMode(): static
     {
         $this->rules->add(new Rule(NoCommentFixer::class));
+
+        return $this;
+    }
+
+    public function withoutRiskyFixers(): static
+    {
+        $this->withoutRiskyFixers = true;
 
         return $this;
     }

--- a/src/Config.php
+++ b/src/Config.php
@@ -23,10 +23,7 @@ class Config
     protected Paths $paths;
     protected Rules $rules;
     protected string $rootPath;
-    /**
-     * @var true
-     */
-    protected bool $withoutRiskyFixers = false;
+    protected bool $withRiskyFixers = true;
 
     public function __construct(
         ?Paths $paths = null,
@@ -56,7 +53,7 @@ class Config
             ->setUsingCache(false)
             ->registerCustomFixers(new PhpCsFixerCustomFixers())
             ->registerCustomFixers($this->getCustomFixers())
-            ->setRiskyAllowed($this->withoutRiskyFixers)
+            ->setRiskyAllowed($this->withRiskyFixers)
             ->setRules($rules);
     }
 
@@ -78,7 +75,7 @@ class Config
 
     public function withoutRiskyFixers(): static
     {
-        $this->withoutRiskyFixers = true;
+        $this->withRiskyFixers = false;
 
         return $this;
     }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -12,7 +12,7 @@ use PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoWhitespaceBeforeCommaInArrayFixer;
 use PhpCsFixer\Fixer\ArrayNotation\TrimArraySpacesFixer;
 use PhpCsFixer\Fixer\ArrayNotation\WhitespaceAfterCommaInArrayFixer;
-use PhpCsFixer\Fixer\Basic\CurlyBracesPositionFixer;
+use PhpCsFixer\Fixer\Basic\BracesPositionFixer;
 use PhpCsFixer\Fixer\Basic\NoMultipleStatementsPerLineFixer;
 use PhpCsFixer\Fixer\Basic\NoTrailingCommaInSinglelineFixer;
 use PhpCsFixer\Fixer\Basic\PsrAutoloadingFixer;
@@ -37,8 +37,8 @@ use PhpCsFixer\Fixer\Comment\NoTrailingWhitespaceInCommentFixer;
 use PhpCsFixer\Fixer\Comment\SingleLineCommentSpacingFixer;
 use PhpCsFixer\Fixer\ControlStructure\ControlStructureBracesFixer;
 use PhpCsFixer\Fixer\ControlStructure\ControlStructureContinuationPositionFixer;
+use PhpCsFixer\Fixer\ControlStructure\NoUnneededBracesFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUnneededControlParenthesesFixer;
-use PhpCsFixer\Fixer\ControlStructure\NoUnneededCurlyBracesFixer;
 use PhpCsFixer\Fixer\ControlStructure\NoUselessElseFixer;
 use PhpCsFixer\Fixer\ControlStructure\TrailingCommaInMultilineFixer;
 use PhpCsFixer\Fixer\ControlStructure\YodaStyleFixer;
@@ -54,6 +54,7 @@ use PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\Import\SingleLineAfterImportsFixer;
+use PhpCsFixer\Fixer\LanguageConstruct\ClassKeywordFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\FunctionToConstantFixer;
@@ -66,7 +67,7 @@ use PhpCsFixer\Fixer\Naming\NoHomoglyphNamesFixer;
 use PhpCsFixer\Fixer\Operator\AssignNullCoalescingToCoalesceEqualFixer;
 use PhpCsFixer\Fixer\Operator\BinaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\ConcatSpaceFixer;
-use PhpCsFixer\Fixer\Operator\NewWithBracesFixer;
+use PhpCsFixer\Fixer\Operator\NewWithParenthesesFixer;
 use PhpCsFixer\Fixer\Operator\NoUselessNullsafeOperatorFixer;
 use PhpCsFixer\Fixer\Operator\ObjectOperatorWithoutWhitespaceFixer;
 use PhpCsFixer\Fixer\Operator\StandardizeIncrementFixer;
@@ -101,7 +102,7 @@ use PhpCsFixer\Fixer\StringNotation\SimpleToComplexStringVariableFixer;
 use PhpCsFixer\Fixer\Whitespace\ArrayIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBeforeStatementFixer;
 use PhpCsFixer\Fixer\Whitespace\BlankLineBetweenImportGroupsFixer;
-use PhpCsFixer\Fixer\Whitespace\CompactNullableTypehintFixer;
+use PhpCsFixer\Fixer\Whitespace\CompactNullableTypeDeclarationFixer;
 use PhpCsFixer\Fixer\Whitespace\LineEndingFixer;
 use PhpCsFixer\Fixer\Whitespace\MethodChainingIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
@@ -141,7 +142,7 @@ class CommonRules extends Rules
         SingleClassElementPerStatementFixer::class => [
             "elements" => ["const", "property"],
         ],
-        NewWithBracesFixer::class => true,
+        NewWithParenthesesFixer::class => true,
         ClassDefinitionFixer::class => [
             "single_line" => true,
         ],
@@ -194,7 +195,7 @@ class CommonRules extends Rules
         NoUnusedImportsFixer::class => true,
         NoEmptyStatementFixer::class => true,
         NoUnneededControlParenthesesFixer::class => true,
-        NoUnneededCurlyBracesFixer::class => true,
+        NoUnneededBracesFixer::class => true,
         DeclareStrictTypesFixer::class => true,
         CastSpacesFixer::class => [
             "space" => "none",
@@ -202,7 +203,9 @@ class CommonRules extends Rules
         DoubleQuoteFixer::class => true,
         VoidReturnFixer::class => true,
         UseArrowFunctionsFixer::class => true,
-        FullyQualifiedStrictTypesFixer::class => true,
+        FullyQualifiedStrictTypesFixer::class => [
+            "import_symbols" => true,
+        ],
         OrderedImportsFixer::class => [
             "sort_algorithm" => "alpha",
             "imports_order" => ["class", "function", "const"],
@@ -255,7 +258,7 @@ class CommonRules extends Rules
         NoLeadingImportSlashFixer::class => true,
         LowercaseCastFixer::class => true,
         LowercaseStaticReferenceFixer::class => true,
-        CompactNullableTypehintFixer::class => true,
+        CompactNullableTypeDeclarationFixer::class => true,
         DeclareEqualNormalizeFixer::class => true,
         ShortScalarCastFixer::class => true,
         CleanNamespaceFixer::class => true,
@@ -328,11 +331,12 @@ class CommonRules extends Rules
         TypeDeclarationSpacesFixer::class => true,
         ControlStructureBracesFixer::class => true,
         ControlStructureContinuationPositionFixer::class => true,
-        CurlyBracesPositionFixer::class => [
+        BracesPositionFixer::class => [
             "anonymous_functions_opening_brace" => "same_line",
         ],
         LowercaseKeywordsFixer::class => true,
         NoMultilineWhitespaceAroundDoubleArrowFixer::class => true,
         CompactEmptyArrayFixer::class => true,
+        ClassKeywordFixer::class => true,
     ];
 }

--- a/tests/codestyle/CommonRulesetTest.php
+++ b/tests/codestyle/CommonRulesetTest.php
@@ -65,6 +65,7 @@ class CommonRulesetTest extends CodestyleTestCase
             ["lowercaseKeywords"],
             ["noMultilineWhitespaceAroundDoubleArrow"],
             ["compactArray"],
+            ["classesImport"],
         ];
     }
 

--- a/tests/fixtures/classesImport/actual.php
+++ b/tests/fixtures/classesImport/actual.php
@@ -1,0 +1,11 @@
+<?php
+
+class TestException extends \Exception
+{
+    protected string $rules = "\Blumilk\Codestyle\Configuration\Defaults\LaravelPaths";
+
+    public function rules(\Blumilk\Codestyle\Configuration\Defaults\CommonRules $rules): void
+    {
+        echo 123;
+    }
+}

--- a/tests/fixtures/classesImport/expected.php
+++ b/tests/fixtures/classesImport/expected.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+use Blumilk\Codestyle\Configuration\Defaults\CommonRules;
+use Blumilk\Codestyle\Configuration\Defaults\LaravelPaths;
+
+class TestException extends Exception
+{
+    protected string $rules = LaravelPaths::class;
+
+    public function rules(CommonRules $rules): void
+    {
+        echo 123;
+    }
+}


### PR DESCRIPTION
With this PR this code:
```php
<?php

class TestException extends \Exception
{
    protected string $rules = "\Blumilk\Codestyle\Configuration\Defaults\LaravelPaths";

    public function rules(\Blumilk\Codestyle\Configuration\Defaults\CommonRules $rules): void
    {
        echo 123;
    }
}
```

should be transformed into:
```php
<?php

declare(strict_types=1);

use Blumilk\Codestyle\Configuration\Defaults\CommonRules;
use Blumilk\Codestyle\Configuration\Defaults\LaravelPaths;

class TestException extends Exception
{
    protected string $rules = LaravelPaths::class;

    public function rules(CommonRules $rules): void
    {
        echo 123;
    }
}
```

So:
* all imports should be imported in import section
* all hardcoded class names should be transformed to FQCNs and imported as well

Additionally:
* deprecated `CurlyBracesPositionFixer` was replaced with `BracesPositionFixer`
* deprecated `NewWithBracesFixer` was replaced with `NewWithParenthesesFixer`
* deprecated `CompactNullableTypehintFixer` was replaced with `CompactNullableTypeDeclarationFixer`

For now it won't pass test cases, as priority of one of new fixers is wrong. We need to wait until https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/pull/7767 would be merged.