### PR TITLE
#43 - named parameters fixer

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -11,6 +11,7 @@ use Blumilk\Codestyle\Configuration\Rules;
 use Blumilk\Codestyle\Configuration\Utils\Rule;
 use Blumilk\Codestyle\Fixers\CompactEmptyArrayFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
+use Blumilk\Codestyle\Fixers\NamedArgumentFixer;
 use Blumilk\Codestyle\Fixers\NoCommentFixer;
 use Blumilk\Codestyle\Fixers\NoLaravelMigrationsGeneratedCommentFixer;
 use JetBrains\PhpStorm\ArrayShape;
@@ -105,6 +106,7 @@ class Config
             new NoLaravelMigrationsGeneratedCommentFixer(),
             new NoCommentFixer(),
             new CompactEmptyArrayFixer(),
+            new NamedArgumentFixer(),
         ];
     }
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -6,6 +6,7 @@ namespace Blumilk\Codestyle\Configuration\Defaults;
 
 use Blumilk\Codestyle\Fixers\CompactEmptyArrayFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
+use Blumilk\Codestyle\Fixers\NamedArgumentFixer;
 use Blumilk\Codestyle\Fixers\NoLaravelMigrationsGeneratedCommentFixer;
 use PhpCsFixer\Fixer\ArrayNotation\ArraySyntaxFixer;
 use PhpCsFixer\Fixer\ArrayNotation\NoMultilineWhitespaceAroundDoubleArrowFixer;
@@ -338,5 +339,6 @@ class CommonRules extends Rules
         NoMultilineWhitespaceAroundDoubleArrowFixer::class => true,
         CompactEmptyArrayFixer::class => true,
         ClassKeywordFixer::class => true,
+        NamedArgumentFixer::class => true,
     ];
 }

--- a/src/Fixers/NamedArgumentFixer.php
+++ b/src/Fixers/NamedArgumentFixer.php
@@ -80,11 +80,11 @@ EOF;
                         $tokens->clearEmptyTokens();
                     }
                 }
-            } elseif($token->isGivenKind(CT::T_NAMED_ARGUMENT_COLON)) {
+            } elseif ($token->isGivenKind(CT::T_NAMED_ARGUMENT_COLON)) {
                 if ($tokens[$index + 1]->isWhitespace() && $tokens[$index + 1]->getContent() !== " ") {
-                    $tokens[$index + 1] = new Token([T_WHITESPACE, ' ']);
+                    $tokens[$index + 1] = new Token([T_WHITESPACE, " "]);
                 } elseif (!$tokens[$index + 1]->isWhitespace()) {
-                    $tokens->insertAt($index + 1, new Token([T_WHITESPACE, ' ']));
+                    $tokens->insertAt($index + 1, new Token([T_WHITESPACE, " "]));
                 }
             }
         }

--- a/src/Fixers/NamedArgumentFixer.php
+++ b/src/Fixers/NamedArgumentFixer.php
@@ -1,0 +1,83 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\Codestyle\Fixers;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Tokens;
+use SplFileInfo;
+
+final class NamedArgumentFixer implements FixerInterface
+{
+    public function getDefinition(): FixerDefinition
+    {
+        $codeSample = <<<'EOF'
+<?php
+if (floatval($percentage) >= (float)$this->option("threshold")) {
+    event(
+        new ErrorsThresholdExceeded(
+            requestsNumber : $requests,
+            errorsNumber   : $errors,
+            percentage     : $percentage,
+        ),
+    );
+}
+EOF;
+
+        return new FixerDefinition(
+            "Fix named arguments formatting.",
+            [
+                new CodeSample($codeSample),
+            ],
+        );
+    }
+
+    public function getName(): string
+    {
+        return "Blumilk/named_arguments";
+    }
+
+    public function getPriority(): int
+    {
+        return 1;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return $tokens->isTokenKindFound(CT::T_NAMED_ARGUMENT_NAME);
+    }
+
+    public function isRisky(): bool
+    {
+        return false;
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        foreach ($tokens as $index => $token) {
+            if (!$token->isGivenKind(CT::T_NAMED_ARGUMENT_NAME)) {
+                continue;
+            }
+
+            $colonIndex = $tokens->getNextMeaningfulToken($index);
+
+            if ($colonIndex !== null && $tokens[$colonIndex]->isGivenKind(CT::T_NAMED_ARGUMENT_COLON)) {
+                $nextIndex = $tokens->getNextNonWhitespace($index);
+
+                if ($nextIndex !== null && $nextIndex === $colonIndex) {
+                    $tokens->clearAt($index + 1);
+                    $tokens->clearEmptyTokens();
+                }
+            }
+        }
+    }
+}

--- a/tests/codestyle/CodestyleTestCase.php
+++ b/tests/codestyle/CodestyleTestCase.php
@@ -35,10 +35,10 @@ abstract class CodestyleTestCase extends TestCase
             "Fixture fixtures/{$name} returned invalid true result.",
         );
 
-        $this->assertTrue(
-            $this->runFixer(fix: true),
-            "Fixture fixtures/{$name} was not proceeded properly.",
-        );
+//        $this->assertTrue(
+//            $this->runFixer(fix: true),
+//            "Fixture fixtures/{$name} was not proceeded properly.",
+//        );
 
         $this->assertFileEquals(
             __DIR__ . "/../fixtures/{$name}/expected.php",

--- a/tests/codestyle/CodestyleTestCase.php
+++ b/tests/codestyle/CodestyleTestCase.php
@@ -35,10 +35,10 @@ abstract class CodestyleTestCase extends TestCase
             "Fixture fixtures/{$name} returned invalid true result.",
         );
 
-//        $this->assertTrue(
-//            $this->runFixer(fix: true),
-//            "Fixture fixtures/{$name} was not proceeded properly.",
-//        );
+        $this->assertTrue(
+            $this->runFixer(fix: true),
+            "Fixture fixtures/{$name} was not proceeded properly.",
+        );
 
         $this->assertFileEquals(
             __DIR__ . "/../fixtures/{$name}/expected.php",

--- a/tests/codestyle/CommonRulesetTest.php
+++ b/tests/codestyle/CommonRulesetTest.php
@@ -66,6 +66,7 @@ class CommonRulesetTest extends CodestyleTestCase
             ["noMultilineWhitespaceAroundDoubleArrow"],
             ["compactArray"],
             ["classesImport"],
+            ["namedParameters"],
         ];
     }
 

--- a/tests/fixtures/namedParameters/actual.php
+++ b/tests/fixtures/namedParameters/actual.php
@@ -1,0 +1,7 @@
+<?php
+
+$class = new ErrorsThresholdExceeded(
+    requestsNumber : $requests,
+    errorsNumber   : $errors,
+    percentage     : $percentage,
+);

--- a/tests/fixtures/namedParameters/actual.php
+++ b/tests/fixtures/namedParameters/actual.php
@@ -1,7 +1,9 @@
 <?php
 
 $class = new ErrorsThresholdExceeded(
-    requestsNumber : $requests,
-    errorsNumber   : $errors,
-    percentage     : $percentage,
+    requestsNumber :$requests,
+    errorsNumber   :  $errors,
+    percentage     :          $percentage,
 );
+
+$result = $reader->merge($merge, new Api(), flag     :   CONSTANT);

--- a/tests/fixtures/namedParameters/expected.php
+++ b/tests/fixtures/namedParameters/expected.php
@@ -1,0 +1,9 @@
+<?php
+
+declare(strict_types=1);
+
+$class = new ErrorsThresholdExceeded(
+    requestsNumber: $requests,
+    errorsNumber: $errors,
+    percentage: $percentage,
+);

--- a/tests/fixtures/namedParameters/expected.php
+++ b/tests/fixtures/namedParameters/expected.php
@@ -7,3 +7,5 @@ $class = new ErrorsThresholdExceeded(
     errorsNumber: $errors,
     percentage: $percentage,
 );
+
+$result = $reader->merge($merge, new Api(), flag: CONSTANT);


### PR DESCRIPTION
Should close #43.
Added named parameters fixer and tests for that fixer.

**Before:**

```
<?php

$class = new ErrorsThresholdExceeded(
    requestsNumber :$requests,
    errorsNumber   :  $errors,
    percentage     :          $percentage,
);

$result = $reader->merge($merge, new Api(), flag     :   CONSTANT);
```

**After:**
```
<?php

declare(strict_types=1);

$class = new ErrorsThresholdExceeded(
    requestsNumber: $requests,
    errorsNumber: $errors,
    percentage: $percentage,
);

$result = $reader->merge($merge, new Api(), flag: CONSTANT);
```

