### PR TITLE
#87 - no empty lines after docblocks

### DIFF
--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -75,6 +75,7 @@ use PhpCsFixer\Fixer\Operator\StandardizeIncrementFixer;
 use PhpCsFixer\Fixer\Operator\TernaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Operator\UnaryOperatorSpacesFixer;
 use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
+use PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
@@ -340,5 +341,6 @@ class CommonRules extends Rules
         CompactEmptyArrayFixer::class => true,
         ClassKeywordFixer::class => true,
         NamedArgumentFixer::class => true,
+        NoBlankLinesAfterPhpdocFixer::class => true,
     ];
 }

--- a/tests/fixtures/emptyLines/actual.php
+++ b/tests/fixtures/emptyLines/actual.php
@@ -2,6 +2,14 @@
 
 declare(strict_types=1);
 
+/**
+ * @property string $id
+ */
+
+class Test
+{
+}
+
 return [
     "default" => env("DB_CONNECTION", "mysql"),
 

--- a/tests/fixtures/emptyLines/expected.php
+++ b/tests/fixtures/emptyLines/expected.php
@@ -2,6 +2,13 @@
 
 declare(strict_types=1);
 
+/**
+ * @property string $id
+ */
+class Test
+{
+}
+
 return [
     "default" => env("DB_CONNECTION", "mysql"),
 


### PR DESCRIPTION
With this PR codestyle package should not accept empty lines between docblocks and other elements.

In general this:

```php
/**
 * @property Uuid $user_id
 * @property Uuid $id
 * (...)
 */

class Alert extends Model
{
```

should be replaces with this:

```php
/**
 * @property Uuid $user_id
 * @property Uuid $id
 * (...)
 */
class Alert extends Model
{
```

Ref:
* https://github.com/blumilksoftware/city-alert-core/blob/90f0973eb894037061ae067fe2d681bf06c2c0ce/app/Models/Alert.php#L37