### PR TITLE
#124 - fix NoCommentFixer.php after 3.59.3 php cs fixer release

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -5,7 +5,7 @@
   "type": "library",
   "require": {
     "php": "^8.1",
-    "friendsofphp/php-cs-fixer": "^3.58",
+    "friendsofphp/php-cs-fixer": "^3.59",
     "kubawerlos/php-cs-fixer-custom-fixers": "^3.21"
   },
   "require-dev": {

--- a/src/Fixers/NoCommentFixer.php
+++ b/src/Fixers/NoCommentFixer.php
@@ -6,6 +6,7 @@ namespace Blumilk\Codestyle\Fixers;
 
 use PhpCsFixer\AbstractFixer;
 use PhpCsFixer\Fixer\ConfigurableFixerInterface;
+use PhpCsFixer\Fixer\ConfigurableFixerTrait;
 use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\FixerConfiguration\FixerConfigurationResolver;
 use PhpCsFixer\FixerConfiguration\FixerOptionBuilder;
@@ -18,7 +19,9 @@ use SplFileInfo;
 
 final class NoCommentFixer extends AbstractFixer implements ConfigurableFixerInterface
 {
-    public function getConfigurationDefinition(): FixerConfigurationResolver
+    use ConfigurableFixerTrait;
+
+    public function createConfigurationDefinition(): FixerConfigurationResolver
     {
         return new FixerConfigurationResolver([
             (new FixerOptionBuilder("doc_comment", "Docblock comments should be removed."))


### PR DESCRIPTION
This PR fixes NoCommentFixer after 3.59.3 php cs fixer release.

Close #124 