### PR TITLE
#112 - class keyword fixer

### DIFF
--- a/src/Config.php
+++ b/src/Config.php
@@ -9,6 +9,7 @@ use Blumilk\Codestyle\Configuration\Defaults\LaravelPaths;
 use Blumilk\Codestyle\Configuration\Paths;
 use Blumilk\Codestyle\Configuration\Rules;
 use Blumilk\Codestyle\Configuration\Utils\Rule;
+use Blumilk\Codestyle\Fixers\ClassKeywordFixer;
 use Blumilk\Codestyle\Fixers\CompactEmptyArrayFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NamedArgumentFixer;
@@ -175,6 +176,7 @@ class Config
             new NoCommentFixer(),
             new CompactEmptyArrayFixer(),
             new NamedArgumentFixer(),
+            new ClassKeywordFixer(),
         ];
     }
 }

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace Blumilk\Codestyle\Configuration\Defaults;
 
+use Blumilk\Codestyle\Fixers\ClassKeywordFixer;
 use Blumilk\Codestyle\Fixers\CompactEmptyArrayFixer;
 use Blumilk\Codestyle\Fixers\DoubleQuoteFixer;
 use Blumilk\Codestyle\Fixers\NamedArgumentFixer;
@@ -56,7 +57,6 @@ use PhpCsFixer\Fixer\Import\NoLeadingImportSlashFixer;
 use PhpCsFixer\Fixer\Import\NoUnusedImportsFixer;
 use PhpCsFixer\Fixer\Import\OrderedImportsFixer;
 use PhpCsFixer\Fixer\Import\SingleLineAfterImportsFixer;
-use PhpCsFixer\Fixer\LanguageConstruct\ClassKeywordFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\DeclareEqualNormalizeFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\ExplicitIndirectVariableFixer;
 use PhpCsFixer\Fixer\LanguageConstruct\FunctionToConstantFixer;

--- a/src/Fixers/ClassKeywordFixer.php
+++ b/src/Fixers/ClassKeywordFixer.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Blumilk\Codestyle\Fixers;
 
 use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\Fixer\Import\FullyQualifiedStrictTypesFixer;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
@@ -73,7 +74,9 @@ $baz = "\Exception";
 
     public function getPriority(): int
     {
-        return 33;
+        $fixer = new FullyQualifiedStrictTypesFixer();
+
+        return $fixer->getPriority() + 1;
     }
 
     public function supports(SplFileInfo $file): bool

--- a/src/Fixers/ClassKeywordFixer.php
+++ b/src/Fixers/ClassKeywordFixer.php
@@ -8,9 +8,7 @@ use PhpCsFixer\Fixer\FixerInterface;
 use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
-use PhpCsFixer\Tokenizer\CT;
 use PhpCsFixer\Tokenizer\Tokens;
-use PhpCsFixerCustomFixers\Fixer\NoCommentedOutCodeFixer;
 use SplFileInfo;
 
 final class ClassKeywordFixer implements FixerInterface
@@ -18,7 +16,7 @@ final class ClassKeywordFixer implements FixerInterface
     public function getDefinition(): FixerDefinitionInterface
     {
         return new FixerDefinition(
-            'Converts FQCN strings to `*::class` keywords.',
+            "Converts FQCN strings to `*::class` keywords.",
             [
                 new CodeSample(
                     '<?php
@@ -26,11 +24,11 @@ final class ClassKeywordFixer implements FixerInterface
 $foo = \'PhpCsFixer\Tokenizer\Tokens\';
 $bar = "\PhpCsFixer\Tokenizer\Tokens";
 $baz = "\Exception";
-'
+',
                 ),
             ],
-            'This rule does not have an understanding of whether a class exists in the scope of the codebase or not, relying on run-time and autoloaded classes to determine it, which makes the rule useless when running on a single file out of codebase context.',
-            'Do not use it, unless you know what you are doing.'
+            "This rule does not have an understanding of whether a class exists in the scope of the codebase or not, relying on run-time and autoloaded classes to determine it, which makes the rule useless when running on a single file out of codebase context.",
+            "Do not use it, unless you know what you are doing.",
         );
     }
 
@@ -49,10 +47,10 @@ $baz = "\Exception";
         for ($index = $tokens->count() - 1; $index >= 0; --$index) {
             $token = $tokens[$index];
 
-            if ($token->isGivenKind(T_CONSTANT_ENCAPSED_STRING) && (strpos($token->getContent(), '\\') !== false)) {
+            if ($token->isGivenKind(T_CONSTANT_ENCAPSED_STRING) && (strpos($token->getContent(), "\\") !== false)) {
                 $name = substr($token->getContent(), 1, -1);
-                $name = ltrim($name, '\\');
-                $name = str_replace('\\\\', '\\', $name);
+                $name = ltrim($name, "\\");
+                $name = str_replace("\\\\", "\\", $name);
 
                 if ($this->exists($name)) {
                     $substitution = Tokens::fromCode("<?php echo \\{$name}::class;");
@@ -65,17 +63,6 @@ $baz = "\Exception";
                 }
             }
         }
-    }
-
-    private function exists(string $name): bool
-    {
-        if (class_exists($name) || interface_exists($name) || trait_exists($name)) {
-            $rc = new \ReflectionClass($name);
-
-            return $rc->getName() === $name;
-        }
-
-        return false;
     }
 
     public function getName(): string
@@ -91,5 +78,16 @@ $baz = "\Exception";
     public function supports(SplFileInfo $file): bool
     {
         return true;
+    }
+
+    private function exists(string $name): bool
+    {
+        if (class_exists($name) || interface_exists($name) || trait_exists($name)) {
+            $rc = new \ReflectionClass($name);
+
+            return $rc->getName() === $name;
+        }
+
+        return false;
     }
 }

--- a/src/Fixers/ClassKeywordFixer.php
+++ b/src/Fixers/ClassKeywordFixer.php
@@ -1,0 +1,95 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Blumilk\Codestyle\Fixers;
+
+use PhpCsFixer\Fixer\FixerInterface;
+use PhpCsFixer\FixerDefinition\CodeSample;
+use PhpCsFixer\FixerDefinition\FixerDefinition;
+use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
+use PhpCsFixer\Tokenizer\CT;
+use PhpCsFixer\Tokenizer\Tokens;
+use PhpCsFixerCustomFixers\Fixer\NoCommentedOutCodeFixer;
+use SplFileInfo;
+
+final class ClassKeywordFixer implements FixerInterface
+{
+    public function getDefinition(): FixerDefinitionInterface
+    {
+        return new FixerDefinition(
+            'Converts FQCN strings to `*::class` keywords.',
+            [
+                new CodeSample(
+                    '<?php
+
+$foo = \'PhpCsFixer\Tokenizer\Tokens\';
+$bar = "\PhpCsFixer\Tokenizer\Tokens";
+$baz = "\Exception";
+'
+                ),
+            ],
+            'This rule does not have an understanding of whether a class exists in the scope of the codebase or not, relying on run-time and autoloaded classes to determine it, which makes the rule useless when running on a single file out of codebase context.',
+            'Do not use it, unless you know what you are doing.'
+        );
+    }
+
+    public function isCandidate(Tokens $tokens): bool
+    {
+        return true;
+    }
+
+    public function isRisky(): bool
+    {
+        return true;
+    }
+
+    public function fix(SplFileInfo $file, Tokens $tokens): void
+    {
+        for ($index = $tokens->count() - 1; $index >= 0; --$index) {
+            $token = $tokens[$index];
+
+            if ($token->isGivenKind(T_CONSTANT_ENCAPSED_STRING) && (strpos($token->getContent(), '\\') !== false)) {
+                $name = substr($token->getContent(), 1, -1);
+                $name = ltrim($name, '\\');
+                $name = str_replace('\\\\', '\\', $name);
+
+                if ($this->exists($name)) {
+                    $substitution = Tokens::fromCode("<?php echo \\{$name}::class;");
+                    $substitution->clearRange(0, 2);
+                    $substitution->clearAt($substitution->getSize() - 1);
+                    $substitution->clearEmptyTokens();
+
+                    $tokens->clearAt($index);
+                    $tokens->insertAt($index, $substitution);
+                }
+            }
+        }
+    }
+
+    private function exists(string $name): bool
+    {
+        if (class_exists($name) || interface_exists($name) || trait_exists($name)) {
+            $rc = new \ReflectionClass($name);
+
+            return $rc->getName() === $name;
+        }
+
+        return false;
+    }
+
+    public function getName(): string
+    {
+        return "Blumilk/class_keyword_fixer";
+    }
+
+    public function getPriority(): int
+    {
+        return 0;
+    }
+
+    public function supports(SplFileInfo $file): bool
+    {
+        return true;
+    }
+}

--- a/src/Fixers/ClassKeywordFixer.php
+++ b/src/Fixers/ClassKeywordFixer.php
@@ -9,6 +9,7 @@ use PhpCsFixer\FixerDefinition\CodeSample;
 use PhpCsFixer\FixerDefinition\FixerDefinition;
 use PhpCsFixer\FixerDefinition\FixerDefinitionInterface;
 use PhpCsFixer\Tokenizer\Tokens;
+use ReflectionClass;
 use SplFileInfo;
 
 final class ClassKeywordFixer implements FixerInterface
@@ -72,7 +73,7 @@ $baz = "\Exception";
 
     public function getPriority(): int
     {
-        return 0;
+        return 33;
     }
 
     public function supports(SplFileInfo $file): bool
@@ -82,10 +83,10 @@ $baz = "\Exception";
 
     private function exists(string $name): bool
     {
-        if (class_exists($name) || interface_exists($name) || trait_exists($name)) {
-            $rc = new \ReflectionClass($name);
+        if (class_exists($name) || interface_exists($name) || trait_exists($name) || enum_exists($name)) {
+            $reflection = new ReflectionClass($name);
 
-            return $rc->getName() === $name;
+            return $reflection->getName() === $name;
         }
 
         return false;

--- a/tests/codestyle/CommonRulesetTest.php
+++ b/tests/codestyle/CommonRulesetTest.php
@@ -68,7 +68,6 @@ class CommonRulesetTest extends CodestyleTestCase
             ["noMultilineWhitespaceAroundDoubleArrow"],
             ["compactArray"],
             ["classesImport"],
-            ["namedParameters"],
         ];
     }
 

--- a/tests/fixtures/classesImport/actual.php
+++ b/tests/fixtures/classesImport/actual.php
@@ -2,10 +2,22 @@
 
 class TestException extends \Exception
 {
-    protected string $rules = "\Blumilk\Codestyle\Configuration\Defaults\LaravelPaths";
+    protected string $var = "Error";
+    protected string $class = "\Error";
+    protected string $laravel = "LaravelPaths";
+    protected string $bar = "\PhpCsFixer\Tokenizer\Tokens";
+    protected string $foo = "PhpCsFixer\Tokenizer\Tokens";
+    protected string $faz = "\Tokens";
 
     public function rules(\Blumilk\Codestyle\Configuration\Defaults\CommonRules $rules): void
     {
         echo 123;
+    }
+
+    public function test(): void
+    {
+        $foo = 'Blumilk\Codestyle\Configuration\Defaults\Paths';
+        $baz = "\Exception";
+        $fuz = "Exception";
     }
 }

--- a/tests/fixtures/classesImport/expected.php
+++ b/tests/fixtures/classesImport/expected.php
@@ -3,14 +3,16 @@
 declare(strict_types=1);
 
 use Blumilk\Codestyle\Configuration\Defaults\CommonRules;
+use Blumilk\Codestyle\Configuration\Defaults\Paths;
+use PhpCsFixer\Tokenizer\Tokens;
 
 class TestException extends Exception
 {
     protected string $var = "Error";
-    protected string $class = \Error::class;
+    protected string $class = Error::class;
     protected string $laravel = "LaravelPaths";
-    protected string $bar = \PhpCsFixer\Tokenizer\Tokens::class;
-    protected string $foo = \PhpCsFixer\Tokenizer\Tokens::class;
+    protected string $bar = Tokens::class;
+    protected string $foo = Tokens::class;
     protected string $faz = "\Tokens";
 
     public function rules(CommonRules $rules): void
@@ -20,8 +22,8 @@ class TestException extends Exception
 
     public function test(): void
     {
-        $foo = \Blumilk\Codestyle\Configuration\Defaults\Paths::class;
-        $baz = \Exception::class;
+        $foo = Paths::class;
+        $baz = Exception::class;
         $fuz = "Exception";
     }
 }

--- a/tests/fixtures/classesImport/expected.php
+++ b/tests/fixtures/classesImport/expected.php
@@ -3,14 +3,25 @@
 declare(strict_types=1);
 
 use Blumilk\Codestyle\Configuration\Defaults\CommonRules;
-use Blumilk\Codestyle\Configuration\Defaults\LaravelPaths;
 
 class TestException extends Exception
 {
-    protected string $rules = LaravelPaths::class;
+    protected string $var = "Error";
+    protected string $class = \Error::class;
+    protected string $laravel = "LaravelPaths";
+    protected string $bar = \PhpCsFixer\Tokenizer\Tokens::class;
+    protected string $foo = \PhpCsFixer\Tokenizer\Tokens::class;
+    protected string $faz = "\Tokens";
 
     public function rules(CommonRules $rules): void
     {
         echo 123;
+    }
+
+    public function test(): void
+    {
+        $foo = \Blumilk\Codestyle\Configuration\Defaults\Paths::class;
+        $baz = \Exception::class;
+        $fuz = "Exception";
     }
 }


### PR DESCRIPTION
Should close #112.

**Before:**
```
class TestException extends \Exception
{
    protected string $var = "Error";
    protected string $class = "\Error";
    protected string $laravel = "LaravelPaths";
    protected string $bar = "\PhpCsFixer\Tokenizer\Tokens";
    protected string $foo = "PhpCsFixer\Tokenizer\Tokens";
    protected string $faz = "\Tokens";

    public function rules(\Blumilk\Codestyle\Configuration\Defaults\CommonRules $rules): void
    {
        echo 123;
    }

    public function test(): void
    {
        $foo = 'Blumilk\Codestyle\Configuration\Defaults\Paths';
        $baz = "\Exception";
        $fuz = "Exception";
    }
}
```

**After:**
```
declare(strict_types=1);

use Blumilk\Codestyle\Configuration\Defaults\CommonRules;

class TestException extends Exception
{
    protected string $var = "Error";
    protected string $class = \Error::class;
    protected string $laravel = "LaravelPaths";
    protected string $bar = \PhpCsFixer\Tokenizer\Tokens::class;
    protected string $foo = \PhpCsFixer\Tokenizer\Tokens::class;
    protected string $faz = "\Tokens";

    public function rules(CommonRules $rules): void
    {
        echo 123;
    }

    public function test(): void
    {
        $foo = \Blumilk\Codestyle\Configuration\Defaults\Paths::class;
        $baz = \Exception::class;
        $fuz = "Exception";
    }
}
```