### PR TITLE
#127 - spaces inside parentheses fixer

### DIFF
--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -113,6 +113,7 @@ use PhpCsFixer\Fixer\Whitespace\NoExtraBlankLinesFixer;
 use PhpCsFixer\Fixer\Whitespace\NoSpacesAroundOffsetFixer;
 use PhpCsFixer\Fixer\Whitespace\NoWhitespaceInBlankLineFixer;
 use PhpCsFixer\Fixer\Whitespace\SingleBlankLineAtEofFixer;
+use PhpCsFixer\Fixer\Whitespace\SpacesInsideParenthesesFixer;
 use PhpCsFixer\Fixer\Whitespace\StatementIndentationFixer;
 use PhpCsFixer\Fixer\Whitespace\TypeDeclarationSpacesFixer;
 use PhpCsFixerCustomFixers\Fixer\CommentedOutFunctionFixer;
@@ -346,5 +347,6 @@ class CommonRules extends Rules
         NoBlankLinesAfterPhpdocFixer::class => true,
         ConstantCaseFixer::class => true,
         PhpUnitAttributesFixer::class => true,
+        SpacesInsideParenthesesFixer::class => true,
     ];
 }

--- a/tests/codestyle/CommonRulesetTest.php
+++ b/tests/codestyle/CommonRulesetTest.php
@@ -68,6 +68,7 @@ class CommonRulesetTest extends CodestyleTestCase
             ["noMultilineWhitespaceAroundDoubleArrow"],
             ["compactArray"],
             ["classesImport"],
+            ["spacesInsideParentheses"],
         ];
     }
 

--- a/tests/fixtures/spacesInsideParentheses/actual.php
+++ b/tests/fixtures/spacesInsideParentheses/actual.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = explode("\\", $class );
+$baz = [ "foo", "bar" , "baz" ];

--- a/tests/fixtures/spacesInsideParentheses/expected.php
+++ b/tests/fixtures/spacesInsideParentheses/expected.php
@@ -1,0 +1,6 @@
+<?php
+
+declare(strict_types=1);
+
+$foo = explode("\\", $class);
+$baz = ["foo", "bar", "baz"];


### PR DESCRIPTION
Should close #127.

Before:
```
<?php

declare(strict_types=1);

$foo = explode("\\", $class );
$baz = [ "foo", "bar" , "baz" ];
```

After:
```
<?php

declare(strict_types=1);

$foo = explode("\\", $class);
$baz = ["foo", "bar", "baz"];
```
