### PR TITLE
#134 - phpdocs items spacing

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -3,5 +3,6 @@
 
 codestyle.php export-ignore
 docker-compose.yml export-ignore
-Makefile export-ignore
 logo.png export-ignore
+Makefile export-ignore
+renovate5.json export-ignore

--- a/composer.json
+++ b/composer.json
@@ -5,13 +5,13 @@
   "type": "library",
   "require": {
     "php": "^8.2",
-    "friendsofphp/php-cs-fixer": "^3.59",
-    "kubawerlos/php-cs-fixer-custom-fixers": "^3.21"
+    "friendsofphp/php-cs-fixer": "^3.70",
+    "kubawerlos/php-cs-fixer-custom-fixers": "^3.23"
   },
   "require-dev": {
     "jetbrains/phpstorm-attributes": "^1.1",
-    "phpunit/phpunit": "^10.0|^11.2",
-    "symfony/console": "^6.0|^7.0"
+    "phpunit/phpunit": "^11.2",
+    "symfony/console": "^7.0"
   },
   "authors": [
     {

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,8 +1,6 @@
-version: "3.7"
-
 services:
   php:
-    image: ghcr.io/blumilksoftware/php:8.2
+    image: ghcr.io/blumilksoftware/php:8.3
     container_name: blumilk-codestyle-php
     working_dir: /application
     user: ${CURRENT_UID:-1000}

--- a/src/Configuration/Defaults/CommonRules.php
+++ b/src/Configuration/Defaults/CommonRules.php
@@ -79,6 +79,7 @@ use PhpCsFixer\Fixer\Phpdoc\GeneralPhpdocAnnotationRemoveFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoBlankLinesAfterPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoEmptyPhpdocFixer;
 use PhpCsFixer\Fixer\Phpdoc\NoSuperfluousPhpdocTagsFixer;
+use PhpCsFixer\Fixer\Phpdoc\PhpdocAlignFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocIndentFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocLineSpanFixer;
 use PhpCsFixer\Fixer\Phpdoc\PhpdocNoEmptyReturnFixer;
@@ -372,5 +373,6 @@ class CommonRules extends Rules
         ConstantCaseFixer::class => true,
         PhpUnitAttributesFixer::class => true,
         SpacesInsideParenthesesFixer::class => true,
+        PhpdocAlignFixer::class => ["align" => "left"],
     ];
 }

--- a/tests/fixtures/phpdocs/actual.php
+++ b/tests/fixtures/phpdocs/actual.php
@@ -29,4 +29,12 @@ class Stub
     {
         $this->i = $this->i + $i;
     }
+
+    /**
+     * @param  int  $i
+     */
+    public function remove($i): void
+    {
+        $this->i = $this->i - $i;
+    }
 }

--- a/tests/fixtures/phpdocs/expected.php
+++ b/tests/fixtures/phpdocs/expected.php
@@ -14,4 +14,12 @@ class Stub
     {
         $this->i = $this->i + $i;
     }
+
+    /**
+     * @param int $i
+     */
+    public function remove($i): void
+    {
+        $this->i = $this->i - $i;
+    }
 }


### PR DESCRIPTION
This PR changes thing like this (completely random, but used by Laravel team):

```php
class VerifyCsrfToken extends BaseVerifyCsrfToken
{
    /**
     * @param Request $request
     * @param  array  $config
     */
    protected function newCookie($request, $config): Cookie
    {
```

to this:
```php
class VerifyCsrfToken extends BaseVerifyCsrfToken
{
    /**
     * @param Request $request
     * @param array $config
     */
    protected function newCookie($request, $config): Cookie
    {
```

Also:
* updated PHP version in docker development mode
* ignore renovate file for Packagist
* updated dependencies

This should close #134.