### PR TITLE
- fix: remove version from composer.json

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,5 @@
 {
   "name": "blumilksoftware/codestyle",
-  "version": "5.0.0",
   "description": "Blumilk codestyle configurator",
   "license": "MIT",
   "type": "library",


### PR DESCRIPTION
This pull request makes a minor change to the `composer.json` file by removing the `version` field, likely to allow version management to be handled elsewhere.

Manually added version broke Packagist versions, and Packagist does not see newer versions like 5.1.0.

- https://packagist.org/packages/blumilksoftware/codestyle

<img width="329" height="382" alt="image" src="https://github.com/user-attachments/assets/78a996c9-e63d-4794-8985-2b168109df3a" />

Also composer docs recommend to remove this key from composr.json
https://getcomposer.org/doc/04-schema.md#version

```Note: Packagist uses VCS repositories, so the statement above is very much true for Packagist as well. Specifying the version yourself will most likely end up creating problems at some point due to human error.```